### PR TITLE
Better type in `Timing` model

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/BenchmarkData.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/BenchmarkData.java
@@ -1,7 +1,5 @@
 package io.quarkus.infra.performance.graphics.model;
 
-import io.quarkus.bootstrap.runner.Timing;
-
 public record BenchmarkData(
         Timing timing, Results results, Config config) {
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Timing.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Timing.java
@@ -1,6 +1,8 @@
 package io.quarkus.infra.performance.graphics.model;
 
+import java.time.Instant;
+
 public record Timing(
-        String start
+        Instant start, Instant stop
 ) {
 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/DataIngesterTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/DataIngesterTest.java
@@ -7,6 +7,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -37,9 +38,13 @@ class DataIngesterTest {
         assertEquals("14G", data.config().cgroup().memMax());
 
         // Results
-
         assertEquals(27586.713333333333, data.results().framework(Framework.QUARKUS3_JVM).load().avThroughput());
         assertEquals(6.496666666666667, data.results().framework(Framework.SPRING3_NATIVE).build().avNativeRSS());
+
+        // Timing
+        assertEquals(Instant.parse("2025-10-20T16:05:51Z"), data.timing().start());
+        assertEquals(Instant.parse("2025-10-20T17:34:02Z"), data.timing().stop());
+
     }
 
 }


### PR DESCRIPTION
@edeandrea  points out using an `Instant` will be safer and better. 

I also spotted that a whole field got lost and an incorrect type got imported when I converted from POJO to records, so I've fixed that.