### PR TITLE
Bake unit information into the model

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -36,7 +36,7 @@ public class BarChart implements Chart {
         g.setPaint(theme.text());
         g.setFont(new Font("Arial", Font.BOLD, 24));
 
-        double maxValue = data.stream().map(Datapoint::value).max(Double::compare).orElse(1.0);
+        double maxValue = data.stream().map(d -> d.value().getValue()).max(Double::compare).orElse(1.0);
 
         int barSpacing = canvasHeight / data.size() - BAR_WIDTH;
         int y = barSpacing / 2;
@@ -47,7 +47,7 @@ public class BarChart implements Chart {
         for (Datapoint d : data) {
             // If this framework isn't found, it will just be the text colour, which is fine
             g.setPaint(theme.chartElements().get(d.framework()));
-            double val = d.value();
+            double val = d.value().getValue();
             int x = labelAllowance - 40; // Fudge factor for asymmetric margins
             double scale = barWidth / maxValue;
             int length = (int) (val * scale);
@@ -59,7 +59,7 @@ public class BarChart implements Chart {
             // Why do we divide by 4 instead of 2? I don't know. :)
             int labelY = y + labelSize / 4 + BAR_WIDTH / 2;
             g.drawString(d.framework().getName(), leftMargin, labelY);
-            g.drawString(java.lang.String.format("%d %s", round(val), "transactions/sec"), x + length + 20, labelY);
+            g.drawString(java.lang.String.format("%d %s", round(val), d.value().getUnits()), x + length + 20, labelY);
 
             y += BAR_WIDTH + barSpacing;
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Datapoint.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Datapoint.java
@@ -1,7 +1,8 @@
 package io.quarkus.infra.performance.graphics.charts;
 
 import io.quarkus.infra.performance.graphics.model.Framework;
+import io.quarkus.infra.performance.graphics.model.units.DimensionalNumber;
 
-public record Datapoint(Framework framework, double value) {
+public record Datapoint(Framework framework, DimensionalNumber value) {
 
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Build.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Build.java
@@ -2,16 +2,21 @@ package io.quarkus.infra.performance.graphics.model;
 
 import java.util.List;
 
-public record Build(
-        List<Double> timings,
-        NativeBuild nativeBuild,  // maps the "native" JSON object,
-        double avBuildTime,
-        Double avNativeRSS,     // optional,
-        String classCount,
-        String fieldCount,
-        String methodCount,
-        String reflectionClassCount,
-        String reflectionFieldCount,
-        String reflectionMethodCount) {
-}
+import io.quarkus.infra.performance.graphics.model.units.ClassCount;
+import io.quarkus.infra.performance.graphics.model.units.FieldCount;
+import io.quarkus.infra.performance.graphics.model.units.Memory;
+import io.quarkus.infra.performance.graphics.model.units.MethodCount;
+import io.quarkus.infra.performance.graphics.model.units.Seconds;
 
+public record Build(
+        List<Seconds> timings,
+        NativeBuild nativeBuild, // maps the "native" JSON object,
+        Seconds avBuildTime,
+        Memory avNativeRSS, // optional,
+        ClassCount classCount,
+        FieldCount fieldCount,
+        MethodCount methodCount,
+        ClassCount reflectionClassCount,
+        FieldCount reflectionFieldCount,
+        MethodCount reflectionMethodCount) {
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Cgroup.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Cgroup.java
@@ -2,9 +2,10 @@ package io.quarkus.infra.performance.graphics.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.quarkus.infra.performance.graphics.model.units.Memory;
+
 public record Cgroup(
-        @JsonProperty("mem_max")
-        String memMax,
+        @JsonProperty("mem_max") Memory memMax,
         String name,
         String cpu) {
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Load.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Load.java
@@ -2,11 +2,15 @@ package io.quarkus.infra.performance.graphics.model;
 
 import java.util.List;
 
+import io.quarkus.infra.performance.graphics.model.units.Memory;
+import io.quarkus.infra.performance.graphics.model.units.TransactionsPerMb;
+import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
+
 public record Load(
-        List<Double> throughput,
-        List<Double> rss,
-        List<Double> throughputDensity,
-        Double avThroughput,
-        Double avMaxRss,
-        Double maxThroughputDensity) {
+        List<TransactionsPerSecond> throughput,
+        List<Memory> rss,
+        List<TransactionsPerMb> throughputDensity,
+        TransactionsPerSecond avThroughput,
+        Memory avMaxRss,
+        TransactionsPerMb maxThroughputDensity) {
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/NativeBuild.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/NativeBuild.java
@@ -2,8 +2,9 @@ package io.quarkus.infra.performance.graphics.model;
 
 import java.util.List;
 
+import io.quarkus.infra.performance.graphics.model.units.Memory;
+
 public record NativeBuild(
-        List<Double> rss,
-        double binarySize
-) {
+        List<Memory> rss,
+        Memory binarySize) {
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Results.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Results.java
@@ -1,12 +1,14 @@
 package io.quarkus.infra.performance.graphics.model;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import io.quarkus.infra.performance.graphics.charts.Datapoint;
-
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+import io.quarkus.infra.performance.graphics.charts.Datapoint;
+import io.quarkus.infra.performance.graphics.model.units.DimensionalNumber;
 
 public class Results {
 
@@ -26,7 +28,7 @@ public class Results {
         return frameworks.get(type);
     }
 
-    public List<Datapoint> getDatasets(Function<Result, Double> fun) {
+    public List<Datapoint> getDatasets(Function<Result, ? extends DimensionalNumber> fun) {
         return frameworks.entrySet().stream().map(e -> new Datapoint(e.getKey(), fun.apply(e.getValue())))
                 .toList();
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Rss.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Rss.java
@@ -2,11 +2,11 @@ package io.quarkus.infra.performance.graphics.model;
 
 import java.util.List;
 
-public record Rss(
-        List<Double> startup,
-        List<Double> firstRequest,
-        Double avStartupRss,
-        Double avFirstRequestRss
-) {
-}
+import io.quarkus.infra.performance.graphics.model.units.Memory;
 
+public record Rss(
+        List<Memory> startup,
+        List<Memory> firstRequest,
+        Memory avStartupRss,
+        Memory avFirstRequestRss) {
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Startup.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Startup.java
@@ -2,8 +2,9 @@ package io.quarkus.infra.performance.graphics.model;
 
 import java.util.List;
 
+import io.quarkus.infra.performance.graphics.model.units.Seconds;
+
 public record Startup(
-        List<Double> timings,
-        Double avStartTime
-) {
+        List<Seconds> timings,
+        Seconds avStartTime) {
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/ClassCount.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/ClassCount.java
@@ -1,0 +1,12 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+public class ClassCount extends DimensionalNumber {
+    public ClassCount(String count) {
+        super(Integer.parseInt(count.replace(",", "")));
+    }
+
+    @Override
+    public String getUnits() {
+        return "classes";
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/DimensionalNumber.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/DimensionalNumber.java
@@ -1,0 +1,17 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+public abstract class DimensionalNumber {
+    // We could do a parameterised type of ? extends Number but doing math with Number is annoying, so stick to doubles and rounding
+    private final double value;
+
+    public DimensionalNumber(double value) {
+        this.value = value;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public abstract String getUnits();
+
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/FieldCount.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/FieldCount.java
@@ -1,0 +1,16 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+public class FieldCount extends DimensionalNumber {
+    public FieldCount(String count) {
+        super(Integer.parseInt(count.replace(",", "")));
+    }
+
+    public FieldCount(int count) {
+        super(count);
+    }
+
+    @Override
+    public String getUnits() {
+        return "fields";
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/Memory.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/Memory.java
@@ -1,0 +1,38 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public class Memory extends DimensionalNumber {
+    private final String units;
+    private static final Pattern UNIT_PATTERN = Pattern.compile("([0-9]+)([A-z]*)");
+
+    @JsonCreator
+    public Memory(String memWithUnits) {
+        super(extractNumber(memWithUnits));
+        this.units = extractUnits(memWithUnits);
+    }
+
+    @JsonCreator
+    public Memory(double mem) {
+        super(mem);
+        this.units = "MB";
+    }
+
+    @Override
+    public String getUnits() {
+        return units;
+    }
+
+    private static double extractNumber(String s) {
+        Matcher m = UNIT_PATTERN.matcher(s.trim());
+        return m.matches() ? Double.parseDouble(m.group(1)) : 0;
+    }
+
+    private static String extractUnits(String s) {
+        Matcher m = UNIT_PATTERN.matcher(s.trim());
+        return m.matches() ? m.group(2) : "MB";
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/MethodCount.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/MethodCount.java
@@ -1,0 +1,12 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+public class MethodCount extends DimensionalNumber {
+    public MethodCount(String count) {
+        super(Integer.parseInt(count.replace(",", "")));
+    }
+
+    @Override
+    public String getUnits() {
+        return "methods";
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/Seconds.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/Seconds.java
@@ -1,0 +1,13 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+// There is a duration class already but we want to extend dimensional number
+public class Seconds extends DimensionalNumber {
+    public Seconds(double duration) {
+        super(duration);
+    }
+
+    @Override
+    public String getUnits() {
+        return "s";
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/TransactionsPerMb.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/TransactionsPerMb.java
@@ -1,0 +1,13 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+public class TransactionsPerMb extends DimensionalNumber {
+
+    public TransactionsPerMb(double throughput) {
+        super(throughput);
+    }
+
+    @Override
+    public String getUnits() {
+        return "transactions/MB";
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/TransactionsPerSecond.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/TransactionsPerSecond.java
@@ -1,0 +1,13 @@
+package io.quarkus.infra.performance.graphics.model.units;
+
+public class TransactionsPerSecond extends DimensionalNumber {
+
+    public TransactionsPerSecond(double throughput) {
+        super(throughput);
+    }
+
+    @Override
+    public String getUnits() {
+        return "transactions/sec";
+    }
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/DataIngesterTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/DataIngesterTest.java
@@ -38,18 +38,22 @@ class DataIngesterTest {
         assertEquals("3.28.4", data.config().quarkus().version());
 
         // CGroup
-        assertEquals("14G", data.config().cgroup().memMax());
+        assertEquals(14, data.config().cgroup().memMax().getValue());
+        assertEquals("G", data.config().cgroup().memMax().getUnits());
 
         // Results
-        assertEquals(27586.713333333333, data.results().framework(Framework.QUARKUS3_JVM).load().avThroughput());
-        assertEquals(6.496666666666667, data.results().framework(Framework.SPRING3_NATIVE).build().avNativeRSS());
+        assertEquals(27586.713333333333, data.results().framework(Framework.QUARKUS3_JVM).load().avThroughput().getValue());
+        assertEquals(6.496666666666667, data.results().framework(Framework.SPRING3_NATIVE).build().avNativeRSS().getValue());
+        assertEquals(35161, data.results().framework(Framework.SPRING3_NATIVE).build().classCount().getValue());
 
         // Timing
         assertEquals(Instant.parse("2025-10-20T16:05:51Z"), data.timing().start());
         assertEquals(Instant.parse("2025-10-20T17:34:02Z"), data.timing().stop());
+        assertEquals(5.526666666666666,
+                data.results().framework(Framework.QUARKUS3_JVM).build().avBuildTime().getValue());
 
         // Native
-        assertEquals("11,620", data.results().framework(Framework.SPRING3_NATIVE).build().reflectionClassCount());
+        assertEquals(11620, data.results().framework(Framework.SPRING3_NATIVE).build().reflectionClassCount().getValue());
     }
 
 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
@@ -1,14 +1,8 @@
 package io.quarkus.infra.performance.graphics;
 
-import io.quarkus.infra.performance.graphics.model.BenchmarkData;
-import io.quarkus.infra.performance.graphics.model.Framework;
-import io.quarkus.infra.performance.graphics.model.Load;
-import io.quarkus.infra.performance.graphics.model.Result;
-import io.quarkus.infra.performance.graphics.model.Results;
-import io.quarkus.test.junit.QuarkusTest;
-import jakarta.inject.Inject;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,9 +11,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.infra.performance.graphics.model.BenchmarkData;
+import io.quarkus.infra.performance.graphics.model.Framework;
+import io.quarkus.infra.performance.graphics.model.Load;
+import io.quarkus.infra.performance.graphics.model.Result;
+import io.quarkus.infra.performance.graphics.model.Results;
+import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class ImageGeneratorTest {
@@ -60,7 +63,7 @@ class ImageGeneratorTest {
         data.results().addFramework(framework.getName(), result);
         Load load = mock(Load.class);
         when(result.load()).thenReturn(load);
-        when(load.avThroughput()).thenReturn(throughput);
+        when(load.avThroughput()).thenReturn(new TransactionsPerSecond(throughput));
     }
 
     @Test

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
@@ -1,13 +1,15 @@
 package io.quarkus.infra.performance.graphics.model;
 
-import io.quarkus.infra.performance.graphics.charts.Datapoint;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.infra.performance.graphics.charts.Datapoint;
+import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
 
 class ResultsTest {
     @Test
@@ -18,9 +20,10 @@ class ResultsTest {
 
         List<Datapoint> datapoints = results.getDatasets(f -> f.load().avThroughput());
         assertEquals(2, datapoints.size());
-        assertEquals(589.21, datapoints.get(0).value());
+        assertEquals(589.21, datapoints.get(0).value().getValue());
         assertEquals(Framework.QUARKUS3_JVM, datapoints.get(0).framework());
-        assertEquals(467.87, datapoints.get(1).value());
+        assertEquals(467.87, datapoints.get(1).value().getValue());
+
     }
 
     private static void addDatapoint(Results results, Framework framework, Double throughput) {
@@ -28,7 +31,7 @@ class ResultsTest {
         results.addFramework(framework.getName(), result);
         Load load = mock(Load.class);
         when(result.load()).thenReturn(load);
-        when(load.avThroughput()).thenReturn(throughput);
+        when(load.avThroughput()).thenReturn(new TransactionsPerSecond(throughput));
     }
 
 }


### PR DESCRIPTION
This is an annoyingly charge changeset which affects nothing in the output. Sorry. 

I’ve baked unit information into the model, to avoid the need to hardcode it in the graphing logic. I’ve also fixed up some cases where the json numbers had commas, and so were incorrectly ingested as strings. In one case unit information was included in the json, so I did some fancy regexping to handle that scenario.