### PR TITLE
Add diagnostics for build NPE

### DIFF
--- a/.github/workflows/graphics.yml
+++ b/.github/workflows/graphics.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Ensure source directory exists
         run: mkdir -p results
       - name: Generate graphics
-        run: java -jar graphics-generator/target/quarkus-app/quarkus-run.jar results images
+        run: java -jar graphics-generator/target/quarkus-app/quarkus-run.jar results images true
       - name: Commit generated resources via PR
         if: github.repository == 'quarkusio/benchmarks' && endsWith(github.ref, '/main') && github.event_name != 'pull_request' 
         id: create-pr

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -18,10 +19,13 @@ import org.w3c.dom.Document;
 import io.quarkus.infra.performance.graphics.charts.BarChart;
 import io.quarkus.infra.performance.graphics.charts.Chart;
 import io.quarkus.infra.performance.graphics.model.BenchmarkData;
+import io.quarkus.infra.performance.graphics.model.Result;
+import io.quarkus.infra.performance.graphics.model.units.DimensionalNumber;
 
 @ApplicationScoped
 public class ImageGenerator {
-    public void generate(BenchmarkData data, File outFile, Theme theme) throws IOException {
+    public void generate(BenchmarkData data, Function<Result, ? extends DimensionalNumber> fun, File outFile, Theme theme)
+            throws IOException {
         String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
         DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
         Document doc = impl.createDocument(svgNS, "svg", null);
@@ -30,7 +34,7 @@ public class ImageGenerator {
         svgGenerator.setSVGCanvasSize(new Dimension(1200, 600));
 
         Chart chart = new BarChart(svgGenerator, theme);
-        chart.draw(data.results().getDatasets(framework -> framework.load().avThroughput()));
+        chart.draw(data.results().getDatasets(fun));
 
         outFile.getParentFile().mkdirs();
         boolean useCSS = true;

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/MissingDataException.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/MissingDataException.java
@@ -1,0 +1,7 @@
+package io.quarkus.infra.performance.graphics;
+
+public class MissingDataException extends RuntimeException {
+    public MissingDataException(String message) {
+        super(message);
+    }
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
@@ -10,6 +10,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Function;
 
 import jakarta.inject.Inject;
 
@@ -21,6 +22,7 @@ import io.quarkus.infra.performance.graphics.model.Framework;
 import io.quarkus.infra.performance.graphics.model.Load;
 import io.quarkus.infra.performance.graphics.model.Result;
 import io.quarkus.infra.performance.graphics.model.Results;
+import io.quarkus.infra.performance.graphics.model.units.DimensionalNumber;
 import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -51,7 +53,8 @@ class ImageGeneratorTest {
             when(data.results()).thenReturn(results);
             addDatapoint(data, Framework.QUARKUS3_JVM, THROUGHPUT);
             addDatapoint(data, Framework.SPRING3_JVM, 267.87);
-            imageGenerator.generate(data, new File("target/images/test1.svg"), Theme.LIGHT);
+            Function<Result, ? extends DimensionalNumber> fun = framework -> framework.load().avThroughput();
+            imageGenerator.generate(data, fun, new File("target/images/test1.svg"), Theme.LIGHT);
             image = new File("target/images/test1.svg");
         } else {
             throw new RuntimeException("How can this be? Target directory not found: " + targetDir.toAbsolutePath());

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.infra.performance.graphics.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -8,6 +10,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.infra.performance.graphics.MissingDataException;
 import io.quarkus.infra.performance.graphics.charts.Datapoint;
 import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
 
@@ -23,6 +26,18 @@ class ResultsTest {
         assertEquals(589.21, datapoints.get(0).value().getValue());
         assertEquals(Framework.QUARKUS3_JVM, datapoints.get(0).framework());
         assertEquals(467.87, datapoints.get(1).value().getValue());
+
+    }
+
+    @Test
+    void getDatasetsForMissingData() {
+        Results results = new Results();
+        addDatapoint(results, Framework.SPRING3_JVM, 589.21);
+
+        Exception exception = assertThrows(MissingDataException.class,
+                () -> results.getDatasets(f -> f.rss().avFirstRequestRss()));
+        assertTrue(exception.getMessage().contains("Rss"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("pring"), exception.getMessage());
 
     }
 


### PR DESCRIPTION
This should get the build back to green. If we want the build to be red when data is missing (which is a reasonable thing to do) setting the tolerate flag to 'false' should generate what images can be generated, and then fail.