### PR TITLE
Add build time charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Benchmark source code: https://github.com/quarkusio/spring-quarkus-perf-comparis
 
 ![](images/spring-quarkus-perf-comparison/results-latest-average-rss-at-first-request-light.svg#gh-light-mode-only)
 ![](images/spring-quarkus-perf-comparison/results-latest-average-rss-at-first-request-dark.svg#gh-dark-mode-only)
+
+
+![](images/spring-quarkus-perf-comparison/results-latest-build-time-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/results-latest-build-time-dark.svg#gh-dark-mode-only)

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
@@ -19,6 +19,8 @@ public class GraphicsCommand implements Runnable {
             framework -> framework.rss().avFirstRequestRss());
     private static final PlotDefinition TIME_TO_FIRST_REQUEST = new PlotDefinition("Boot + First Response Time",
             framework -> framework.startup().avStartTime());
+    private static final PlotDefinition BUILD_TIME = new PlotDefinition("Build Time",
+            framework -> framework.build().avBuildTime());
 
     @Parameters(paramLabel = "<filename>", defaultValue = "latest.json", description = "A filename of json-formatted data, or a directory. For directories, .json files in the directory will be processed recursively.")
     Path filename;
@@ -81,6 +83,7 @@ public class GraphicsCommand implements Runnable {
         generate(file, qualifiedOutputDir, data, RSS);
         generate(file, qualifiedOutputDir, data, TIME_TO_FIRST_REQUEST);
         generate(file, qualifiedOutputDir, data, THROUGHPUT);
+        generate(file, qualifiedOutputDir, data, BUILD_TIME);
     }
 
     private void generate(File file, File qualifiedOutputDir, BenchmarkData data, PlotDefinition plotDefinition) {


### PR DESCRIPTION
This is a less useful chart, but it's one of the only ones we can generate at the moment, and I want to be exercising the chart generation flows. 

Example output:

<img width="1316" height="594" alt="image" src="https://github.com/user-attachments/assets/6e2675f9-25f5-459f-bfdd-eefd000877b1" />