### PR TITLE
Add token to fix CI failure

### DIFF
--- a/.github/workflows/graphics.yml
+++ b/.github/workflows/graphics.yml
@@ -56,5 +56,7 @@ jobs:
           labels: |
             Generated Resources
       - name: Merge PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: (steps.create-pr.outputs.pull-request-operation == 'created') && (steps.create-pr.outputs.pull-request-number)
         run: gh pr merge --merge --delete-branch "${{ steps.create-pr.outputs.pull-request-url }}"


### PR DESCRIPTION
```
Run gh pr merge --merge --delete-branch "https://github.com/quarkusio/benchmarks/pull/31"
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```