### PR TITLE
Use Open Sans, and ensure fonts work across all operating systems

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
@@ -1,11 +1,17 @@
 package io.quarkus.infra.performance.graphics;
 
 import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -14,6 +20,7 @@ import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.svggen.SVGGraphics2D;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import io.quarkus.infra.performance.graphics.charts.BarChart;
 import io.quarkus.infra.performance.graphics.charts.Chart;
@@ -21,9 +28,23 @@ import io.quarkus.infra.performance.graphics.model.BenchmarkData;
 
 @ApplicationScoped
 public class ImageGenerator {
+    private static final String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
+
+    // To make fonts work, we need a css declaration (below), and we also need to tell Java about the font (done here)
+    static {
+        // Java needs a ttf font, not a woff, so read from the github repo
+        String fontUrl = "https://github.com/googlefonts/opensans/raw/refs/heads/main/fonts/variable/OpenSans%5Bwdth,wght%5D.ttf";
+        try (InputStream fontStream = new URI(fontUrl).toURL().openStream()) {
+            Font openSans = Font.createFont(Font.TRUETYPE_FONT, fontStream);
+            GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+            ge.registerFont(openSans);
+        } catch (FontFormatException | URISyntaxException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void generate(BenchmarkData data, PlotDefinition plotDefinition, File outFile, Theme theme)
             throws IOException {
-        String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
         DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
         Document doc = impl.createDocument(svgNS, "svg", null);
 
@@ -33,13 +54,37 @@ public class ImageGenerator {
         Chart chart = new BarChart(svgGenerator, theme);
         chart.draw(plotDefinition.title(), data.results().getDatasets(plotDefinition.fun()));
 
+        Element root = svgGenerator.getRoot();
+        initialiseFonts(doc, root);
+
         outFile.getParentFile().mkdirs();
-        boolean useCSS = true;
         try (Writer out = new OutputStreamWriter(new FileOutputStream(outFile), StandardCharsets.UTF_8)) {
-            svgGenerator.stream(out, useCSS);
+            svgGenerator.stream(root, out, true, false);
             System.out.printf("\uD83C\uDFA8 Wrote SVG image to %s\n", outFile.getAbsolutePath());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
+
+    private static void initialiseFonts(Document doc, Element root) {
+        //Annoyingly, we can't use the same URLs as we use to register the font, and we also can't use the current v44 versions of the fonts
+        String styleContent = """
+                @font-face {
+                    font-family: 'Open Sans';
+                    font-style: normal;
+                    font-weight: 300;
+                    src: url(https://fonts.gstatic.com/s/opensans/v20/mem5YaGs126MiZpBA-UN_r8OUuhpKKSTjw.woff2) format('woff2');
+                                                                                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                }
+                @font-face {
+                    font-family: 'Open Sans';
+                    font-style: normal;
+                    font-weight: 400 700;
+                    src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2');
+                                                                                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                }
+                """;
+        Element style = doc.createElementNS(svgNS, "style");
+        style.setTextContent(styleContent);
+        root.insertBefore(style, root.getFirstChild());
+    }
+
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
@@ -9,6 +9,8 @@ import io.quarkus.infra.performance.graphics.model.Framework;
 
 public record Theme(Color background, Color text, Map<Framework, Color> chartElements) {
 
+    public static final String FONT = "Open Sans";
+
     public static Theme LIGHT = new Theme(Color.WHITE, Color.BLACK,
             Map.of(Framework.QUARKUS3_JVM, decode("#4695EB"), Framework.QUARKUS3_NATIVE, decode("#FF0000"),
                     Framework.QUARKUS3_SPRING_COMPAT, decode("#0D1C2C"), Framework.SPRING3_JVM, decode("#676767"),

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -18,9 +18,9 @@ public class BarChart implements Chart {
     private final Theme theme;
     private int labelSize = 24;
 
-    private static final Font titleFont = new Font("Arial", Font.BOLD, 24);
-    private static final Font keyFont = new Font("Arial", Font.BOLD, 18);
-    private static final Font labelFont = new Font("Arial", Font.PLAIN, 14);
+    private static final Font titleFont = new Font(Theme.FONT, Font.BOLD, 24);
+    private static final Font keyFont = new Font(Theme.FONT, Font.BOLD, 18);
+    private static final Font labelFont = new Font(Theme.FONT, Font.PLAIN, 14);
 
     public BarChart(SVGGraphics2D g, Theme theme) {
         this.g = g;


### PR DESCRIPTION
The reason fonts were broken on the CI-generated images is that Linux machines don't have Arial. We didn't want to use Arial anyway, since the quarkus.io graphs are open sans. So I've switched to using that font.

<img width="1093" height="574" alt="image" src="https://github.com/user-attachments/assets/87336ae8-670f-4e4d-9481-a48fd49fbcec" />
