### PR TITLE
Embed font into image

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
@@ -1,17 +1,11 @@
 package io.quarkus.infra.performance.graphics;
 
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontFormatException;
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -29,19 +23,6 @@ import io.quarkus.infra.performance.graphics.model.BenchmarkData;
 @ApplicationScoped
 public class ImageGenerator {
     private static final String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
-
-    // To make fonts work, we need a css declaration (below), and we also need to tell Java about the font (done here)
-    static {
-        // Java needs a ttf font, not a woff, so read from the github repo
-        String fontUrl = "https://github.com/googlefonts/opensans/raw/refs/heads/main/fonts/variable/OpenSans%5Bwdth,wght%5D.ttf";
-        try (InputStream fontStream = new URI(fontUrl).toURL().openStream()) {
-            Font openSans = Font.createFont(Font.TRUETYPE_FONT, fontStream);
-            GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-            ge.registerFont(openSans);
-        } catch (FontFormatException | URISyntaxException | IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     public void generate(BenchmarkData data, PlotDefinition plotDefinition, File outFile, Theme theme)
             throws IOException {
@@ -65,25 +46,8 @@ public class ImageGenerator {
     }
 
     private static void initialiseFonts(Document doc, Element root) {
-        //Annoyingly, we can't use the same URLs as we use to register the font, and we also can't use the current v44 versions of the fonts
-        String styleContent = """
-                @font-face {
-                    font-family: 'Open Sans';
-                    font-style: normal;
-                    font-weight: 300;
-                    src: url(https://fonts.gstatic.com/s/opensans/v20/mem5YaGs126MiZpBA-UN_r8OUuhpKKSTjw.woff2) format('woff2');
-                                                                                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-                }
-                @font-face {
-                    font-family: 'Open Sans';
-                    font-style: normal;
-                    font-weight: 400 700;
-                    src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2');
-                                                                                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-                }
-                """;
         Element style = doc.createElementNS(svgNS, "style");
-        style.setTextContent(styleContent);
+        style.setTextContent(Theme.FONT.getCss());
         root.insertBefore(style, root.getFirstChild());
     }
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
@@ -5,11 +5,12 @@ import static java.awt.Color.decode;
 import java.awt.Color;
 import java.util.Map;
 
+import io.quarkus.infra.performance.graphics.charts.EmbeddableFont;
 import io.quarkus.infra.performance.graphics.model.Framework;
 
 public record Theme(Color background, Color text, Map<Framework, Color> chartElements) {
 
-    public static final String FONT = "Open Sans";
+    public static final EmbeddableFont FONT = EmbeddableFont.OPENSANS;
 
     public static Theme LIGHT = new Theme(Color.WHITE, Color.BLACK,
             Map.of(Framework.QUARKUS3_JVM, decode("#4695EB"), Framework.QUARKUS3_NATIVE, decode("#FF0000"),

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -18,9 +18,9 @@ public class BarChart implements Chart {
     private final Theme theme;
     private int labelSize = 24;
 
-    private static final Font titleFont = new Font(Theme.FONT, Font.BOLD, 24);
-    private static final Font keyFont = new Font(Theme.FONT, Font.BOLD, 18);
-    private static final Font labelFont = new Font(Theme.FONT, Font.PLAIN, 14);
+    private static final Font titleFont = new Font(Theme.FONT.getName(), Font.BOLD, 24);
+    private static final Font keyFont = new Font(Theme.FONT.getName(), Font.BOLD, 18);
+    private static final Font labelFont = new Font(Theme.FONT.getName(), Font.PLAIN, 14);
 
     public BarChart(SVGGraphics2D g, Theme theme) {
         this.g = g;

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/EmbeddableFont.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/EmbeddableFont.java
@@ -1,0 +1,72 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.GraphicsEnvironment;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Base64;
+
+public class EmbeddableFont {
+
+    // Java GraphicsEnvironment needs a ttf font, not a woff, so read from the github repo
+    public static final EmbeddableFont OPENSANS = new EmbeddableFont("Open Sans",
+            "https://github.com/googlefonts/opensans/raw/refs/heads/main/fonts/variable/OpenSans%5Bwdth,wght%5D.ttf");
+    private final String css;
+    private final String fontName;
+
+    private EmbeddableFont(String fontName, String fontUrl) {
+
+        this.fontName = fontName;
+        try {
+            // Download the font file
+            byte[] fontBytes = downloadFont(fontUrl);
+
+            // To make fonts work, we need a css declaration (below), and we also need to tell Java about the font (done here)
+            try (InputStream stream = new ByteArrayInputStream(fontBytes)) {
+                Font openSans = java.awt.Font.createFont(Font.TRUETYPE_FONT, stream);
+                GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+                ge.registerFont(openSans);
+            } catch (FontFormatException | IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Base64 encode the font bytes
+            String base64Font = Base64.getEncoder().encodeToString(fontBytes);
+
+            css = generateFontFaceCSS(fontName, base64Font);
+
+        } catch (URISyntaxException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getCss() {
+        return css;
+    }
+
+    public String getName() {
+        return fontName;
+    }
+
+    private static byte[] downloadFont(String fontUrl) throws URISyntaxException, IOException {
+        try (InputStream in = new URI(fontUrl).toURL().openStream()) {
+            return in.readAllBytes();
+        }
+    }
+
+    private static String generateFontFaceCSS(String fontName, String base64Font) {
+        return """
+                @font-face {
+                  font-family: '%s';
+                  src: url('data:font/ttf;base64, %s') format('truetype');
+                  font-weight: 300 600;
+                  font-style: normal;
+                }
+                """.formatted(fontName, base64Font);
+    }
+
+}


### PR DESCRIPTION
This is required for the fonts to display when the image is embedded into a web page, or viewed online. See https://stackoverflow.com/questions/2057716/svg-font-face-works-in-svg-but-not-when-included-in-a-page.

This does increase the image sizes from 4kb to 713kb, sadly. We could probably embed fewer of the characters if we tried, but it would be a bit fiddly.