### PR TITLE
Right align framework labels

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Alignment.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Alignment.java
@@ -1,0 +1,7 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+public enum Alignment {
+    CENTER,
+    LEFT,
+    RIGHT
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -53,10 +53,10 @@ public class BarChart implements Chart {
 
         int y = 0;
 
-        Subcanvas labelArea = new Subcanvas(chartArea, labelAllowance, plotHeight, 0, 0);
         // Fudge factor for asymmetric margins
         int fudge = 40;
-        Subcanvas barArea = new Subcanvas(chartArea, barWidth, plotHeight, labelAllowance - fudge, 0);
+        Subcanvas labelArea = new Subcanvas(chartArea, labelAllowance - fudge, plotHeight, 0, 0);
+        Subcanvas barArea = new Subcanvas(chartArea, barWidth, plotHeight, labelArea.getWidth(), 0);
 
         for (Datapoint d : data) {
             // If this framework isn't found, it will just be the text colour, which is fine
@@ -69,7 +69,9 @@ public class BarChart implements Chart {
             labelArea.setPaint(theme.text());
             // Vertically align text with the centre of the bars
             int labelY = y + BAR_THICKNESS / 2;
-            new Label(d.framework().getExpandedName(), 0, labelY).setTargetHeight(BAR_THICKNESS).draw(labelArea);
+            new Label(d.framework().getExpandedName(), labelArea.getWidth() - labelPadding, labelY)
+                    .setHorizontalAlignment(Alignment.RIGHT)
+                    .setTargetHeight(BAR_THICKNESS).draw(labelArea);
             new Label(java.lang.String.format("%d %s", round(val), d.value().getUnits()),
                     length + labelPadding,
                     labelY).setStyle(Font.BOLD).setTargetHeight(BAR_THICKNESS * 2 / 3).draw(barArea);

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
@@ -15,6 +15,7 @@ public class Label {
     // The g.getGraphics().getFontMetrics().getHeight() number is 39-40% bigger than the notional font size; use it to estimate what font size we might need to set
     private static final double realHeightRatio = 1.4;
     private int style = Font.PLAIN;
+    private Alignment alignment = Alignment.LEFT;
 
     /**
      * @param text Use \n for multiline text
@@ -46,9 +47,14 @@ public class Label {
 
         // Compute starting y to vertically center the text block
         int yPosition = y - textBlockHeight / 2 + fontMetrics.getAscent();
-
         for (String string : strings) {
-            g.drawString(string, x, yPosition);
+            int width = fontMetrics.stringWidth(string);
+            int alignedX = switch (alignment) {
+                case LEFT -> x;
+                case RIGHT -> x - width;
+                case CENTER -> x - width / 2;
+            };
+            g.drawString(string, alignedX, yPosition);
             yPosition += lineHeight;
         }
 
@@ -57,6 +63,11 @@ public class Label {
     // We will need to have a labelGroup abstraction to keep sizes consistent, and perhaps also set a maximum width
     public Label setTargetHeight(int height) {
         this.targetHeight = height;
+        return this;
+    }
+
+    public Label setHorizontalAlignment(Alignment alignment) {
+        this.alignment = alignment;
         return this;
     }
 


### PR DESCRIPTION
The bar charts are now almost identical to the reference image, except for the missing scale. 

<img width="1177" height="376" alt="image" src="https://github.com/user-attachments/assets/c425fe9a-ae6f-450a-9cd3-4e2a0b8318eb" />
