### PR TITLE
Make element sizing a bit more elastic

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
@@ -3,16 +3,16 @@ package io.quarkus.infra.performance.graphics;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.function.BiFunction;
+import java.util.List;
 
 import jakarta.inject.Inject;
-
-import org.apache.batik.svggen.SVGGraphics2D;
 
 import io.quarkus.infra.performance.graphics.charts.BarChart;
 import io.quarkus.infra.performance.graphics.charts.Chart;
 import io.quarkus.infra.performance.graphics.charts.CubeChart;
+import io.quarkus.infra.performance.graphics.charts.Datapoint;
 import io.quarkus.infra.performance.graphics.model.BenchmarkData;
+import io.quarkus.infra.performance.graphics.model.Config;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
@@ -96,7 +96,8 @@ public class GraphicsCommand implements Runnable {
         generate(file, qualifiedOutputDir, BarChart::new, data, BUILD_TIME);
     }
 
-    private void generate(File file, File qualifiedOutputDir, BiFunction<SVGGraphics2D, Theme, Chart> chartConstructor,
+    private void generate(File file, File qualifiedOutputDir,
+            TriFunction<String, List<Datapoint>, Config, Chart> chartConstructor,
             BenchmarkData data, PlotDefinition plotDefinition) {
         String fileMod = plotDefinition.title().toLowerCase().replaceAll(" ", "-").replaceAll("\\+", "and");
         try {

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/RandomColor.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/RandomColor.java
@@ -1,0 +1,17 @@
+package io.quarkus.infra.performance.graphics;
+
+import java.awt.Color;
+import java.util.Random;
+
+public class RandomColor {
+    private static final Random rand = new Random();
+    private static final Color[] COLORS = {
+            Color.BLACK, Color.BLUE, Color.CYAN, Color.DARK_GRAY, Color.GRAY,
+            Color.GREEN, Color.LIGHT_GRAY, Color.MAGENTA, Color.ORANGE,
+            Color.PINK, Color.RED, Color.WHITE, Color.YELLOW
+    };
+
+    public static Color nextColor() {
+        return COLORS[rand.nextInt(COLORS.length)];
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/TriFunction.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/TriFunction.java
@@ -1,0 +1,16 @@
+package io.quarkus.infra.performance.graphics;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+@FunctionalInterface
+interface TriFunction<A, B, C, R> {
+
+    R apply(A a, B b, C c);
+
+    default <V> TriFunction<A, B, C, V> andThen(
+            Function<? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (A a, B b, C c) -> after.apply(apply(a, b, c));
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
@@ -1,0 +1,123 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import static java.lang.Math.round;
+
+import java.awt.Font;
+
+import io.quarkus.infra.performance.graphics.Theme;
+import io.quarkus.infra.performance.graphics.VAlignment;
+
+public class Bar implements ElasticElement {
+    private static final int BAR_THICKNESS = 44;
+    public static final int VALUE_LABEL_HEIGHT = BAR_THICKNESS * 2 / 3;
+    private static final int MINIMUM_BAR_THICKNESS = 44;
+    private static final int MAXIMUM_BAR_THICKNESS = 44;
+    private static final int MINUMUM_FONT_SIZE = 8;
+    private static final int MINIMUM_BAR_LENGTH = 200;
+
+    public static final int LEFT_LABEL_SIZE = Sizer.calculateFontSize(BAR_THICKNESS / 2);
+    public static final int RIGHT_LABEL_SIZE = Sizer.calculateFontSize(VALUE_LABEL_HEIGHT);
+
+    private static final int barSpacing = 12;
+    private static final int labelPadding = 6;
+
+    private final String valueLabelText;
+    private final Label valueLabel;
+    private final Label frameworkLabel;
+    private final Datapoint d;
+
+    private double scale = 1;
+    private int leftLabelWidth;
+    private String frameworkLabelText;
+
+    public Bar(Datapoint d) {
+        this.d = d;
+        double val = d.value().getValue();
+        frameworkLabelText = d.framework().getExpandedName();
+        frameworkLabel = new Label(frameworkLabelText)
+                .setHorizontalAlignment(Alignment.RIGHT)
+                .setVerticalAlignment(VAlignment.MIDDLE)
+                .setTargetHeight(BAR_THICKNESS);
+        valueLabelText = String.format("%d %s", round(val), d.value().getUnits());
+        valueLabel = new Label(valueLabelText).setStyle(Font.BOLD)
+                .setTargetHeight(VALUE_LABEL_HEIGHT);
+
+        // This will probably be overridden, but set a value
+        leftLabelWidth = Sizer.calculateWidth(frameworkLabelText, LEFT_LABEL_SIZE);
+    }
+
+    public void setScale(double scale) {
+        this.scale = scale;
+    }
+
+    // Allows alignment of a group of bars
+    public void setLeftLabelWidth(int w) {
+        this.leftLabelWidth = w;
+    }
+
+    @Override
+    public int getMaximumVerticalSize() {
+        return MAXIMUM_BAR_THICKNESS + barSpacing;
+    }
+
+    @Override
+    public int getMaximumHorizontalSize() {
+        // Arbitrary; we can go big
+        return 3000;
+    }
+
+    @Override
+    public int getMinimumVerticalSize() {
+        return MINIMUM_BAR_THICKNESS + barSpacing;
+    }
+
+    @Override
+    public int getMinimumHorizontalSize() {
+        return leftLabelWidth + MINIMUM_BAR_LENGTH + getValueLabelWidth() + 2 * labelPadding;
+    }
+
+    private int getValueLabelWidth() {
+        return Sizer.calculateWidth(valueLabelText, RIGHT_LABEL_SIZE, Font.BOLD);
+    }
+
+    public String getLeftLabelText() {
+        return frameworkLabelText;
+    }
+
+    public String getRightLabelText() {
+        return valueLabelText;
+    }
+
+    @Override
+    public void draw(Subcanvas barArea, Theme theme) {
+        double val = d.value().getValue();
+        // Vertically align text with the centre of the bars
+        int labelY = BAR_THICKNESS / 2;
+
+        barArea.setPaint(theme.text());
+
+        Subcanvas frameworkSubcanvas = new Subcanvas(barArea, leftLabelWidth, frameworkLabel.getTargetHeight(), 0, 0);
+        frameworkLabel.draw(frameworkSubcanvas, leftLabelWidth, labelY);
+        int xOffset = frameworkSubcanvas.getWidth() + labelPadding;
+        Subcanvas barSubcanvas = new Subcanvas(barArea, barArea.getWidth() - xOffset,
+                frameworkLabel.getTargetHeight(), xOffset, 0);
+
+        // If this framework isn't found, it will just be the text colour, which is fine
+        barSubcanvas.setPaint(theme.chartElements().get(d.framework()));
+        int length = (int) (val * scale);
+        barSubcanvas.fillRect(0, 0, length, BAR_THICKNESS);
+
+        barSubcanvas.setPaint(theme.text());
+
+        valueLabel.setTargetHeight(BAR_THICKNESS * 2 / 3).draw(barSubcanvas, length + labelPadding,
+                labelY);
+    }
+
+    public int getMaximumBarWidth(Subcanvas barArea) {
+        return barArea.getWidth() - 2 * labelPadding - leftLabelWidth - getValueLabelWidth();
+    }
+
+    public double getMaximumScale(Subcanvas barArea) {
+        return getMaximumBarWidth(barArea) / d.value().getValue();
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -1,93 +1,84 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import static java.lang.Math.round;
-
-import java.awt.Font;
 import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.apache.batik.svggen.SVGGraphics2D;
+import java.util.stream.Collectors;
 
 import io.quarkus.infra.performance.graphics.Theme;
 import io.quarkus.infra.performance.graphics.model.Config;
 
-public class BarChart implements Chart {
-    private static final int BAR_THICKNESS = 44;
-    private static final int barSpacing = 12;
-    private static final int labelPadding = 6;
+public class BarChart extends Chart {
 
-    private final SVGGraphics2D g;
-    private final int canvasHeight;
-    private final int canvasWidth;
-    private final Theme theme;
-    private FinePrint fineprint;
+    private final FinePrint fineprint;
+    private final List<Bar> bars = new ArrayList<>();
 
-    public BarChart(SVGGraphics2D g, Theme theme) {
-        this.g = g;
-        this.theme = theme;
-        this.canvasHeight = g.getSVGCanvasSize().height;
-        this.canvasWidth = g.getSVGCanvasSize().width;
+    public BarChart(String titleText, List<Datapoint> data, Config metadata) {
+        super(titleText, data, metadata);
+
+        this.fineprint = new FinePrint(metadata);
+        children.add(fineprint);
+
+        for (Datapoint d : data) {
+            Bar e = new Bar(d);
+            bars.add(e);
+            children.add(e);
+        }
 
     }
 
     @Override
-    public void draw(String title, List<Datapoint> data, Config metadata) {
+    protected void drawNoCheck(Subcanvas g, Theme theme) {
+        int canvasHeight = g.getHeight();
+        int canvasWidth = g.getWidth();
 
         g.setPaint(theme.background());
         g.fill(new Rectangle2D.Double(0, 0, canvasWidth, canvasWidth));
 
-        g.setPaint(theme.text());
+        int margins = 20;
+        int ymargins = 20;
 
-        double maxValue = data.stream().map(d -> d.value().getValue()).max(Double::compare).orElse(1.0);
-
-        int labelAllowance = 180;
-        int leftMargin = 20;
-        int barWidth = canvasWidth - 2 * labelAllowance;
-
-        int titleTextSize = 48;
-        Subcanvas titleCanvas = new Subcanvas(g, canvasWidth, titleTextSize * 2, leftMargin, 0);
-        new Label(title, 0, titleTextSize).setTargetHeight(titleTextSize).setStyle(Font.BOLD).draw(titleCanvas);
-
-        int plotWidth = canvasWidth - 2 * leftMargin;
         int finePrintHeight = 80;
-        int plotHeight = canvasHeight - titleCanvas.getHeight() - finePrintHeight;
-        Subcanvas chartArea = new Subcanvas(g, plotWidth, plotHeight, leftMargin, titleCanvas.getHeight());
+
+        Subcanvas canvasWithMargins = new Subcanvas(g, canvasWidth - 2 * margins, canvasHeight - 2 * ymargins, margins,
+                ymargins);
+
+        g.setPaint(theme.text());
+        Subcanvas titleCanvas = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(), titleTextSize * 2, 0, 0);
+        titleLabel.setTargetHeight(titleTextSize).draw(titleCanvas, 0, titleTextSize);
+
+        Subcanvas barArea = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(),
+                canvasWithMargins.getHeight() - titleCanvas.getHeight() - finePrintHeight, 0, titleCanvas.getHeight());
+
+        int leftLabelWidth = Sizer.calculateWidth(bars.stream().map(Bar::getLeftLabelText).collect(Collectors.toSet()),
+                Bar.LEFT_LABEL_SIZE);
+
+        // Set a common left label width before trying to calculate a scale
+        for (Bar bar : bars) {
+            bar.setLeftLabelWidth(leftLabelWidth);
+        }
+
+        double scale = bars.stream().mapToDouble(bar -> bar.getMaximumScale(barArea)).min().orElse(1);
 
         int y = 0;
 
-        // Fudge factor for asymmetric margins
-        int fudge = 40;
-        Subcanvas labelArea = new Subcanvas(chartArea, labelAllowance - fudge, plotHeight, 0, 0);
-        Subcanvas barArea = new Subcanvas(chartArea, barWidth, plotHeight, labelArea.getWidth(), 0);
-        int finePrintPadding = 300;
-        Subcanvas finePrintArea = new Subcanvas(chartArea, barWidth - 2 * finePrintPadding, finePrintHeight, finePrintPadding,
-                barArea.getHeight() - 50); // TODO Arbitrary fudge padding, remove when scaling work is done
+        int finePrintPadding = 300; // TODO Arbitrary fudge padding, remove when scaling work is done
+        Subcanvas finePrintArea = new Subcanvas(canvasWithMargins, barArea.getWidth() - 2 * finePrintPadding, finePrintHeight,
+                finePrintPadding,
+                barArea.getHeight());
+        g.setPaint(theme.text());
 
-        for (Datapoint d : data) {
-            // If this framework isn't found, it will just be the text colour, which is fine
-            barArea.setPaint(theme.chartElements().get(d.framework()));
-            double val = d.value().getValue();
-            double scale = barWidth / maxValue;
-            int length = (int) (val * scale);
-            barArea.fillRect(0, y, length, BAR_THICKNESS);
-
-            labelArea.setPaint(theme.text());
-            // Vertically align text with the centre of the bars
-            int labelY = y + BAR_THICKNESS / 2;
-            new Label(d.framework().getExpandedName(), labelArea.getWidth() - labelPadding, labelY)
-                    .setHorizontalAlignment(Alignment.RIGHT)
-                    .setTargetHeight(BAR_THICKNESS).draw(labelArea);
-            new Label(java.lang.String.format("%d %s", round(val), d.value().getUnits()),
-                    length + labelPadding,
-                    labelY).setStyle(Font.BOLD).setTargetHeight(BAR_THICKNESS * 2 / 3).draw(barArea);
-
-            y += BAR_THICKNESS + barSpacing;
+        for (Bar bar : bars) {
+            bar.setScale(scale);
+            // TODO slight hack, assuming the min and max are always equal
+            Subcanvas individualBarArea = new Subcanvas(barArea, barArea.getWidth(), bar.getMaximumVerticalSize(), 0, y);
+            bar.draw(individualBarArea, theme);
+            y += individualBarArea.getHeight();
 
         }
 
-        this.fineprint = new FinePrint(finePrintArea, theme);
-        fineprint.draw(metadata);
+        fineprint.draw(finePrintArea, theme);
     }
 
     @Override

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
@@ -1,18 +1,77 @@
 package io.quarkus.infra.performance.graphics.charts;
 
+import java.awt.Font;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import io.quarkus.infra.performance.graphics.Theme;
 import io.quarkus.infra.performance.graphics.model.Config;
 
-public interface Chart {
+public abstract class Chart implements ElasticElement {
 
-    void draw(String title, List<Datapoint> datasets, Config metadata);
+    protected final Label titleLabel;
+    protected final int titleTextSize = 48;
+
+    protected final List<Datapoint> data;
+    protected final String title;
+    protected final Config metadata;
+    // For size calculations, the assumption is that these are stacked vertically
+    protected final Set<ElasticElement> children;
+
+    protected final double maxValue;
+
+    protected Chart(String title, List<Datapoint> datasets, Config metadata) {
+        this.data = datasets;
+        this.title = title;
+        this.metadata = metadata;
+        children = new HashSet<>();
+
+        titleLabel = new Label(title).setStyle(Font.BOLD);
+
+        // TODO title not included in vertical height
+        maxValue = data.stream().map(d -> d.value().getValue()).max(Double::compare).orElse(1.0);
+    }
+
+    public void draw(Subcanvas g, Theme theme) {
+        if (getMinimumHorizontalSize() > g.getWidth()) {
+            throw new SizeException("Cannot fit " + getMinimumHorizontalSize() + "px of content into a " + g.getHeight()
+                    + "px horizontal space.");
+        }
+        if (getMinimumVerticalSize() > g.getHeight()) {
+            throw new SizeException("Cannot fit " + getMinimumHorizontalSize() + "px of content into a " + g.getHeight()
+                    + "px vertical space.");
+        }
+        drawNoCheck(g, theme);
+    }
+
+    protected abstract void drawNoCheck(Subcanvas g, Theme theme);
 
     // SVGs after to be done *after* the main drawing, because getting the document root before drawing causes all subsequent draws to be dropped.
     // This seems to be a characteristic of the Batik streaming model.
-    default Collection<InlinedSVG> getInlinedSVGs() {
+    public Collection<InlinedSVG> getInlinedSVGs() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public int getMaximumVerticalSize() {
+        return children.stream().mapToInt(ElasticElement::getMaximumVerticalSize).sum();
+    }
+
+    @Override
+    public int getMaximumHorizontalSize() {
+        return children.stream().mapToInt(ElasticElement::getMaximumHorizontalSize).max().orElse(0);
+    }
+
+    @Override
+    public int getMinimumVerticalSize() {
+        return children.stream().mapToInt(ElasticElement::getMinimumVerticalSize).sum();
+    }
+
+    @Override
+    public int getMinimumHorizontalSize() {
+        return children.stream().mapToInt(ElasticElement::getMinimumHorizontalSize).max().orElse(0);
     }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/ElasticElement.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/ElasticElement.java
@@ -1,0 +1,15 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import io.quarkus.infra.performance.graphics.Theme;
+
+public interface ElasticElement {
+    int getMaximumVerticalSize();
+
+    int getMaximumHorizontalSize();
+
+    int getMinimumVerticalSize();
+
+    int getMinimumHorizontalSize();
+
+    void draw(Subcanvas g, Theme theme);
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
@@ -9,12 +9,8 @@ import io.quarkus.infra.performance.graphics.VAlignment;
 public class Label {
 
     private final String[] strings;
-    private final int x;
-    private final int y;
     private int targetHeight = 24; // Arbitrary default
     private double lineSpacing = 1;
-    // The g.getGraphics().getFontMetrics().getHeight() number is 39-40% bigger than the notional font size; use it to estimate what font size we might need to set
-    private static final double realHeightRatio = 1.4;
     private int style = Font.PLAIN;
     private Alignment alignment = Alignment.LEFT;
     private VAlignment valignment = VAlignment.MIDDLE;
@@ -24,24 +20,23 @@ public class Label {
 
     /**
      * @param text Use \n for multiline text
-     * @param x
-     * @param y The y position of the center of the text
      */
-    public Label(String text, int x, int y) {
+    public Label(String text) {
         this.strings = text.split("\n");
-        this.x = x;
-        this.y = y;
+
     }
 
-    public Label(String[] lines, int x, int y) {
+    public Label(String[] lines) {
         this.strings = lines;
-        this.x = x;
-        this.y = y;
     }
 
     public void draw(Subcanvas g) {
-        int size = strings.length > 1 ? (int) (targetHeight / (strings.length * lineSpacing * realHeightRatio))
-                : (int) (targetHeight / (realHeightRatio));
+        draw(g, 0, 0);
+    }
+
+    public void draw(Subcanvas g, int x, int y) {
+        int size = strings.length > 1 ? Sizer.calculateFontSize((int) (targetHeight / (strings.length * lineSpacing)))
+                : Sizer.calculateFontSize(targetHeight);
         Font font = new Font(Theme.FONT.getName(), style, size);
         g.getGraphics().setFont(font);
 
@@ -83,6 +78,10 @@ public class Label {
     public Label setTargetHeight(int height) {
         this.targetHeight = height;
         return this;
+    }
+
+    public int getTargetHeight() {
+        return targetHeight;
     }
 
     public Label setHorizontalAlignment(Alignment alignment) {

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/SizeException.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/SizeException.java
@@ -1,0 +1,7 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+public class SizeException extends RuntimeException {
+    public SizeException(String s) {
+        super(s);
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Sizer.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Sizer.java
@@ -1,0 +1,88 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.batik.anim.dom.SVGDOMImplementation;
+import org.apache.batik.svggen.SVGGraphics2D;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+
+import io.quarkus.infra.performance.graphics.Theme;
+
+public class Sizer {
+    // The g.getGraphics().getFontMetrics().getHeight() number is 39-40% bigger than the notional font size; use it to estimate what font size we might need to set
+    private static final double REAL_HEIGHT_RATIO = 1.4;
+
+    private static final String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
+
+    // Dummy graphics, just for font metrics
+    private static final SVGGraphics2D g;
+
+    static {
+        DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
+        Document doc = impl.createDocument(svgNS, "svg", null);
+
+        g = new SVGGraphics2D(doc);
+    }
+    private static final Map<Integer, Font> fonts = new HashMap<>();
+    private static final Map<Integer, Font> boldFonts = new HashMap<>();;
+
+    private static String longestString(Collection<String> strings) {
+        return strings.stream()
+                .flatMap(s -> Arrays.stream(s.split("\n")))
+                .max((a, b) -> Integer.compare(a.length(), b.length()))
+                .orElse("");
+    }
+
+    public static int calculateWidth(Collection<String> strings, int fontSize) {
+        String longest = longestString(strings);
+        return calculateWidthNoLineBreaks(longest, fontSize, Font.PLAIN);
+    }
+
+    public static int calculateWidth(String string, int fontSize) {
+        String longest = longestString(List.of(string.split("\n")));
+        return calculateWidthNoLineBreaks(longest, fontSize, Font.PLAIN);
+    }
+
+    public static int calculateWidth(String string, int fontSize, int fontStyle) {
+        String longest = longestString(List.of(string.split("\n")));
+        return calculateWidthNoLineBreaks(longest, fontSize, fontStyle);
+    }
+
+    private static int calculateWidthNoLineBreaks(String longest, int fontSize, int fontStyle) {
+        Font font = getFont(fontSize, fontStyle);
+        FontMetrics fm = g.getFontMetrics(font);
+        return fm.stringWidth(longest);
+    }
+
+    private static Font getFont(int fontSize, int fontStyle) {
+        if (fontStyle == Font.BOLD) {
+            return boldFonts.computeIfAbsent(fontSize, s -> new Font(Theme.FONT.getName(), Font.BOLD, s));
+        } else {
+            return fonts.computeIfAbsent(fontSize, s -> new Font(Theme.FONT.getName(), Font.PLAIN, s));
+        }
+    }
+
+    public static int calculateHeight(int fontSize) {
+        Font font = getFont(fontSize, Font.PLAIN);
+        FontMetrics fm = g.getFontMetrics(font);
+        return fm.getHeight();
+    }
+
+    public static int calculateFontSize(int targetHeight) {
+        int fontSize = (int) (targetHeight / REAL_HEIGHT_RATIO);
+        while (calculateHeight(fontSize) > targetHeight) {
+            fontSize--;
+        }
+        while (calculateHeight(fontSize) < targetHeight) {
+            fontSize++;
+        }
+        return fontSize;
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Subcanvas.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Subcanvas.java
@@ -1,11 +1,17 @@
 package io.quarkus.infra.performance.graphics.charts;
 
+import static io.quarkus.infra.performance.graphics.RandomColor.nextColor;
+
 import java.awt.Color;
+import java.awt.geom.Rectangle2D;
 
 import org.apache.batik.svggen.SVGGraphics2D;
 
 // we won't implement all of Graphics2D, since we only use a few methods
 public class Subcanvas {
+
+    public static boolean debug = false;
+
     private final SVGGraphics2D g;
     private final int width;
     private final int height;
@@ -26,6 +32,17 @@ public class Subcanvas {
         this.height = height;
         this.xOffset = subcanvas.xOffset + xOffset;
         this.yOffset = subcanvas.yOffset + yOffset;
+
+        if (debug) {
+            Color originalColor = g.getColor();
+            g.setPaint(nextColor());
+            fillRect(0, 0, width, height);
+            g.setPaint(originalColor);
+        }
+    }
+
+    public Subcanvas(SVGGraphics2D g) {
+        this(g, g.getSVGCanvasSize().width, g.getSVGCanvasSize().height, 0, 0);
     }
 
     public void setPaint(Color color) {
@@ -34,6 +51,10 @@ public class Subcanvas {
 
     public void fillRect(int x, int y, int width, int height) {
         g.fillRect(x + xOffset, y + yOffset, width, height);
+    }
+
+    public void fill(Rectangle2D.Double aDouble) {
+        g.fill(new Rectangle2D.Double(aDouble.x + xOffset, aDouble.y + yOffset, aDouble.getWidth(), aDouble.getHeight()));
     }
 
     public void drawString(String name, int x, int y) {

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/SizerTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/SizerTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Font;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class SizerTest {
+
+    @Test
+    void calculateWidthForSingleString() {
+        // It's hard to reason about the exact right values here, so hardcode some expectations
+        assertEquals(66, Sizer.calculateWidth("some string", 12));
+        assertEquals(100, Sizer.calculateWidth("some string", 18));
+    }
+
+    @Test
+    void calculateWidthForSingleStringWithStyle() {
+        // It's hard to reason about the exact right values here, so hardcode some expectations
+        assertEquals(70, Sizer.calculateWidth("some string", 12, Font.BOLD));
+        assertEquals(106, Sizer.calculateWidth("some string", 18, Font.BOLD));
+    }
+
+    @Test
+    void calculateWidthForCollectionOfStrings() {
+        assertEquals(Sizer.calculateWidth("some string", 12),
+                Sizer.calculateWidth(Set.of("short", "some string", "tiddly"), 12));
+    }
+
+    @Test
+    void calculateWidthForCollectionOfStringsWithLineBreaks() {
+        assertEquals(Sizer.calculateWidth("some string", 12),
+                Sizer.calculateWidth(Set.of("short\ns", "yup\nsome string\nok", "tiddly\nwinks"), 12));
+    }
+
+    @Test
+    void calculateHeight() {
+        // The actual space occupied by a font is bigger than the notional size, because of descents and other font parts
+        assertEquals(17, Sizer.calculateHeight(12));
+    }
+
+    @Test
+    void calculateFontSize() {
+        assertEquals(12, Sizer.calculateFontSize(17));
+    }
+
+}


### PR DESCRIPTION
This is a big big refactor for a small external change, but it starts to unlock other things, like #56, #57, and #58. In order to position elements properly, I had to switch round the logic so that elements are initialised with the data and then drawn against the graphics constructs, instead of having the canvas present on initialisation and the data deferred.

So far what's changed is that the label on the throughput graphs is no longer truncated. The position of the fine print on the throughput graph is better, but not on the cube chart. 

Not all elements correctly implement the ElasticElement contracts and it's a bit fragile and I'm not sure how best to test it, but it's progress in the right direction. 