### PR TITLE
Add Spring 4 to data model, only display version in label if needed

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
@@ -12,15 +12,42 @@ public record Theme(Color background, Color text, Map<Framework, Color> chartEle
 
     public static final EmbeddableFont FONT = EmbeddableFont.OPENSANS;
 
-    public static Theme LIGHT = new Theme(Color.WHITE, Color.BLACK,
-            Map.of(Framework.QUARKUS3_JVM, decode("#4695EB"), Framework.QUARKUS3_NATIVE, decode("#FF0000"),
-                    Framework.QUARKUS3_SPRING_COMPAT, decode("#0D1C2C"), Framework.SPRING3_JVM, decode("#676767"),
-                    Framework.SPRING3_NATIVE, decode("#444444"), Framework.SPRING3_JVM_AOT, decode("#808080")));
+    public static Theme LIGHT = new Theme(
+            Color.WHITE,
+            Color.BLACK,
+            Map.ofEntries(
+                    Map.entry(Framework.QUARKUS3_JVM, decode("#4695EB")),
+                    Map.entry(Framework.QUARKUS3_NATIVE, decode("#FF0000")),
+                    Map.entry(Framework.QUARKUS3_SPRING_COMPAT, decode("#0D1C2C")),
 
-    public static final Theme DARK = new Theme(Color.BLACK, Color.WHITE,
-            Map.of(Framework.QUARKUS3_JVM, decode("#71AEEF"), Framework.QUARKUS3_NATIVE, decode("#70CA8D"),
-                    Framework.QUARKUS3_SPRING_COMPAT, decode("#0D1C2C"),
-                    Framework.SPRING3_JVM, decode("#999999"),
-                    Framework.SPRING3_NATIVE, decode("#777777"), Framework.SPRING3_JVM_AOT, decode("#AAAAAA")));
+                    // Greyscale values for Spring
+                    Map.entry(Framework.SPRING3_JVM, decode("#EEEEEE")),
+                    Map.entry(Framework.SPRING3_NATIVE, decode("#D2D2D2")),
+                    Map.entry(Framework.SPRING3_JVM_AOT, decode("#B6B6B6")),
+                    Map.entry(Framework.SPRING4_JVM, decode("#9A9A9A")),
+                    Map.entry(Framework.SPRING4_NATIVE, decode("#7E7E7E")),
+                    Map.entry(Framework.SPRING4_JVM_AOT, decode("#626262")),
+                    Map.entry(Framework.SPRING_JVM, decode("#464646")),
+                    Map.entry(Framework.SPRING_NATIVE, decode("#2A2A2A")),
+                    Map.entry(Framework.SPRING_JVM_AOT, decode("#0E0E0E"))));
+
+    public static final Theme DARK = new Theme(
+            Color.BLACK,
+            Color.WHITE,
+            Map.ofEntries(
+                    Map.entry(Framework.QUARKUS3_JVM, decode("#71AEEF")),
+                    Map.entry(Framework.QUARKUS3_NATIVE, decode("#70CA8D")),
+                    Map.entry(Framework.QUARKUS3_SPRING_COMPAT, decode("#0D1C2C")),
+
+                    // Lightish grey values for Spring
+                    Map.entry(Framework.SPRING3_JVM, decode("#F2F2F2")),
+                    Map.entry(Framework.SPRING3_NATIVE, decode("#E4E4E4")),
+                    Map.entry(Framework.SPRING3_JVM_AOT, decode("#D6D6D6")),
+                    Map.entry(Framework.SPRING4_JVM, decode("#C8C8C8")),
+                    Map.entry(Framework.SPRING4_NATIVE, decode("#BABABA")),
+                    Map.entry(Framework.SPRING4_JVM_AOT, decode("#ACACAC")),
+                    Map.entry(Framework.SPRING_JVM, decode("#9E9E9E")),
+                    Map.entry(Framework.SPRING_NATIVE, decode("#909090")),
+                    Map.entry(Framework.SPRING_JVM_AOT, decode("#888888"))));
 
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/FinePrint.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/FinePrint.java
@@ -38,6 +38,19 @@ public class FinePrint implements ElasticElement {
         if (metadata.springboot() != null) {
             leftColumn.add("Spring: "
                     + metadata.springboot().version());
+            // If there's only one Spring, strip the qualifier
+            // Assume the truth is in the data, and what's in the data set is what is being plotted
+        } else if (metadata.springboot3() != null && metadata.springboot4() == null) {
+            leftColumn.add("Spring: "
+                    + metadata.springboot3().version());
+        } else if (metadata.springboot4() != null && metadata.springboot3() == null) {
+            leftColumn.add("Spring: "
+                    + metadata.springboot4().version());
+        } else if (metadata.springboot3() != null && metadata.springboot4() != null) {
+            leftColumn.add("Spring 3: "
+                    + metadata.springboot3().version());
+            leftColumn.add("Spring 4: "
+                    + metadata.springboot4().version());
         }
         if (metadata.jvm() != null) {
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Config.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Config.java
@@ -5,23 +5,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record Config(
         Jvm jvm,
 
-        @JsonProperty("CMD_PREFIX")
-        String cmdPrefix,
+        @JsonProperty("CMD_PREFIX") String cmdPrefix,
 
-        @JsonProperty("num_iterations")
-        int numIterations,
+        @JsonProperty("num_iterations") int numIterations,
 
         FrameworkBuild quarkus,
 
-        @JsonProperty("repo")
-        Repo repo,
+        @JsonProperty("repo") Repo repo,
 
-        @JsonProperty("profiler")
-        Profiler profiler,
+        @JsonProperty("profiler") Profiler profiler,
 
-        @JsonProperty("cgroup")
-        Cgroup cgroup,
+        @JsonProperty("cgroup") Cgroup cgroup,
 
-        FrameworkBuild springboot
+        // Present for backwards compatibility
+        FrameworkBuild springboot,
+
+        FrameworkBuild springboot3,
+
+        FrameworkBuild springboot4
+
 ) {
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Framework.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Framework.java
@@ -10,11 +10,19 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum Framework {
     // The order of these determines the natural order in the charts
     QUARKUS3_JVM("quarkus3-jvm", "Quarkus + JIT\n(via OpenJDK)"),
-    SPRING3_JVM("spring3-jvm", "Spring + JIT\n(via OpenJDK)"),
-    SPRING3_JVM_AOT("spring3-jvm-aot", "Spring AOT\n(via OpenJDK)"),
+    SPRING_JVM("spring-jvm", "Spring + JIT\n(via OpenJDK)"),
+    SPRING4_JVM("spring4-jvm", "Spring 4 + JIT\n(via OpenJDK)"),
+    SPRING3_JVM("spring3-jvm", "Spring 3 + JIT\n(via OpenJDK)"),
+    SPRING4_JVM_AOT("spring4-jvm-aot", "Spring 4 AOT\n(via OpenJDK)"),
+    SPRING_JVM_AOT("spring-jvm-aot", "Spring AOT\n(via OpenJDK)"),
+    SPRING3_JVM_AOT("spring3-jvm-aot", "Spring 3 AOT\n(via OpenJDK)"),
     QUARKUS3_NATIVE("quarkus3-native", "Quarkus + Native\n(via GraalVM)"),
-    SPRING3_NATIVE("spring3-native", "Spring + Native\n(via GraalVM)"),
-    QUARKUS3_SPRING_COMPAT("quarkus3-spring-compat", "Spring\n with Quarkus compatibility libraries");
+    SPRING_NATIVE("spring-native", "Spring + Native\n(via GraalVM)"),
+    SPRING4_NATIVE("spring4-native", "Spring 4 + Native\n(via GraalVM)"),
+    SPRING3_NATIVE("spring3-native", "Spring 3 + Native\n(via GraalVM)"),
+    QUARKUS3_SPRING_COMPAT("quarkus3-spring-compat", "Quarkus\n with Spring compatibility libraries"),
+    QUARKUS3_SPRING4_COMPAT("quarkus3-spring4-compat", "Quarkus\n with Spring 4 compatibility libraries"),
+    QUARKUS3_SPRING3_COMPAT("quarkus3-spring3-compat", "Quarkus\n with Spring 3 compatibility libraries");
 
     private final String name;
     private final String expandedName;

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Results.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Results.java
@@ -30,9 +30,42 @@ public class Results {
     }
 
     public List<Datapoint> getDatasets(Function<Result, ? extends DimensionalNumber> fun) {
+        // Adjust the frameworks to unqualified ones if there's not different versions of the same framework
+        // There's no perfect place to do this, but this seems like a reasonable place
+
+        if (hasOnlyOneSpringVersion(frameworks)) {
+            swap(Framework.SPRING3_JVM, Framework.SPRING_JVM);
+            swap(Framework.SPRING3_NATIVE, Framework.SPRING_NATIVE);
+            swap(Framework.SPRING3_JVM_AOT, Framework.SPRING_JVM_AOT);
+            swap(Framework.QUARKUS3_SPRING3_COMPAT, Framework.QUARKUS3_SPRING_COMPAT);
+
+            swap(Framework.SPRING4_JVM, Framework.SPRING_JVM);
+            swap(Framework.SPRING4_NATIVE, Framework.SPRING_NATIVE);
+            swap(Framework.SPRING4_JVM_AOT, Framework.SPRING_JVM_AOT);
+            swap(Framework.QUARKUS3_SPRING4_COMPAT, Framework.QUARKUS3_SPRING_COMPAT);
+        }
+
         return frameworks.entrySet().stream().map(e -> getDatapoint(e, fun))
                 .toList();
 
+    }
+
+    private boolean hasOnlyOneSpringVersion(Map<Framework, Result> frameworks) {
+        boolean hasSpring3 = frameworks.containsKey(Framework.SPRING3_JVM) || frameworks.containsKey(Framework.SPRING3_NATIVE)
+                || frameworks.containsKey(Framework.SPRING3_JVM_AOT);
+        boolean hasSpring4 = frameworks.containsKey(Framework.SPRING4_JVM) || frameworks.containsKey(Framework.SPRING4_NATIVE)
+                || frameworks.containsKey(Framework.SPRING4_JVM_AOT);
+
+        // Use xor
+        return hasSpring3 ^ hasSpring4;
+
+    }
+
+    private void swap(Framework qualified, Framework simple) {
+        if (frameworks.containsKey(qualified)) {
+            frameworks.put(simple, frameworks.get(qualified));
+            frameworks.remove(qualified);
+        }
     }
 
     private static Datapoint getDatapoint(Map.Entry<Framework, Result> entry,

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ElasticElementTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ElasticElementTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.StringWriter;
+
+import org.apache.batik.anim.dom.SVGDOMImplementation;
+import org.apache.batik.svggen.SVGGraphics2D;
+import org.apache.batik.svggen.SVGGraphics2DIOException;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+
+import io.quarkus.infra.performance.graphics.Theme;
+
+public class ElasticElementTest {
+    protected static final String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
+
+    protected String drawSvg(ElasticElement e) {
+        DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
+        Document doc = impl.createDocument(svgNS, "svg", null);
+
+        SVGGraphics2D g = new SVGGraphics2D(doc);
+
+        e.draw(new Subcanvas(g, 900, 900, 0, 0), Theme.DARK);
+
+        StringWriter writer = new StringWriter();
+        try {
+            g.stream(writer, true);
+        } catch (SVGGraphics2DIOException ex) {
+            fail(ex);
+        }
+
+        String svgString = writer.toString();
+        return svgString;
+
+    }
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/FinePrintTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/FinePrintTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.infra.performance.graphics.model.Config;
+import io.quarkus.infra.performance.graphics.model.FrameworkBuild;
+import io.quarkus.infra.performance.graphics.model.Repo;
+
+class FinePrintTest extends ElasticElementTest {
+
+    @Test
+    public void quarkusVersionIsPresent() {
+        Config config = mock(Config.class);
+        when(config.repo()).thenReturn(new Repo("main", "somerepo"));
+        when(config.quarkus()).thenReturn(new FrameworkBuild("", "3.28.3"));
+
+        FinePrint p = new FinePrint(config);
+        String s = drawSvg(p);
+        assertTrue(s.contains("3.28.3"), s);
+    }
+
+    @Test
+    public void quarkusVersionIsLabelled() {
+        Config config = mock(Config.class);
+        when(config.repo()).thenReturn(new Repo("main", "somerepo"));
+        when(config.quarkus()).thenReturn(new FrameworkBuild("", "3.28.3"));
+
+        FinePrint p = new FinePrint(config);
+        String s = drawSvg(p);
+        assertTrue(s.contains("Quarkus: 3.28.3"), s);
+    }
+
+    @Test
+    public void unqualifiedSpringVersionIsLabelled() {
+        Config config = mock(Config.class);
+        when(config.repo()).thenReturn(new Repo("main", "somerepo"));
+        when(config.springboot()).thenReturn(new FrameworkBuild("", "3.10.3"));
+
+        FinePrint p = new FinePrint(config);
+        String s = drawSvg(p);
+        assertTrue(s.contains("Spring: 3.10.3"), s);
+    }
+
+    @Test
+    public void qualifiedSpringVersionIsLabelledForSpring3() {
+        Config config = mock(Config.class);
+        when(config.repo()).thenReturn(new Repo("main", "somerepo"));
+        when(config.springboot3()).thenReturn(new FrameworkBuild("", "3.10.3"));
+        FinePrint p = new FinePrint(config);
+        String s = drawSvg(p);
+        assertTrue(s.contains("Spring: 3.10.3"), s);
+
+    }
+
+    @Test
+    public void qualifiedSpringVersionIsLabelledForSpring4() {
+        Config config = mock(Config.class);
+        when(config.repo()).thenReturn(new Repo("main", "somerepo"));
+        when(config.springboot4()).thenReturn(new FrameworkBuild("", "4.10.3"));
+        FinePrint p = new FinePrint(config);
+        String s = drawSvg(p);
+        assertTrue(s.contains("Spring: 4.10.3"), s);
+
+    }
+
+    @Test
+    public void springVersionsHaveDistinctLabelsWhenMultipleArePresent() {
+        Config config = mock(Config.class);
+        when(config.repo()).thenReturn(new Repo("main", "somerepo"));
+        when(config.springboot3()).thenReturn(new FrameworkBuild("", "3.10.3"));
+        when(config.springboot4()).thenReturn(new FrameworkBuild("", "4.10.3"));
+        FinePrint p = new FinePrint(config);
+        String s = drawSvg(p);
+        assertTrue(s.contains("Spring 3: 3.10.3"), s);
+        assertTrue(s.contains("Spring 4: 4.10.3"), s);
+
+    }
+
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/FrameworkTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/FrameworkTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.infra.performance.graphics.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FrameworkTest {
+    @Test
+    void getExpandedNameForSimpleQuarkusCase() {
+        assertEquals("Quarkus + JIT\n(via OpenJDK)", Framework.QUARKUS3_JVM.getExpandedName());
+    }
+
+    @Test
+    void getExpandedNameForSimpleSpringCase() {
+        assertEquals("Spring 3 + JIT\n(via OpenJDK)", Framework.SPRING3_JVM.getExpandedName());
+    }
+
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
@@ -30,6 +30,40 @@ class ResultsTest {
     }
 
     @Test
+    void getDatasetsAdjustsFrameworksWhenOnlyOnePresent() {
+        Results results = new Results();
+        addDatapoint(results, Framework.QUARKUS3_JVM, 589.21);
+        addDatapoint(results, Framework.SPRING3_JVM, 467.87);
+
+        List<Datapoint> datapoints = results.getDatasets(f -> f.load().avThroughput());
+        assertEquals(2, datapoints.size());
+        assertEquals(589.21, datapoints.get(0).value().getValue());
+        // The second framework should be a synthetic one to reflect the fact there's only one Spring version
+        assertEquals(Framework.SPRING_JVM, datapoints.get(1).framework());
+        assertEquals(467.87, datapoints.get(1).value().getValue());
+    }
+
+    @Test
+    void getDatasetsDoesNotAdjustFrameworksWhenMultiplesPresent() {
+        Results results = new Results();
+        addDatapoint(results, Framework.SPRING4_JVM, 42.1);
+        addDatapoint(results, Framework.QUARKUS3_JVM, 589.21);
+        addDatapoint(results, Framework.SPRING3_JVM, 467.87);
+
+        List<Datapoint> datapoints = results.getDatasets(f -> f.load().avThroughput());
+        assertEquals(3, datapoints.size());
+        assertEquals(589.21, datapoints.get(0).value().getValue());
+        assertEquals(Framework.QUARKUS3_JVM, datapoints.get(0).framework());
+
+        assertEquals(Framework.SPRING4_JVM, datapoints.get(1).framework());
+        assertEquals(42.1, datapoints.get(1).value().getValue());
+
+        assertEquals(Framework.SPRING3_JVM, datapoints.get(2).framework());
+        assertEquals(467.87, datapoints.get(2).value().getValue());
+
+    }
+
+    @Test
     void getDatasetsForMissingData() {
         Results results = new Results();
         addDatapoint(results, Framework.SPRING3_JVM, 589.21);


### PR DESCRIPTION
Resolves #82 

I've added the spring4 fields to the config and result data objects. 
I've also added some logic so that if only Spring 3 or Spring 4 is measured, we're DRY and don't clutter the labels with the version number. When both are present, the version number is shown. 

I've also added more tests, which is nice.

This may need some tweaking, especially on the fine print part, once we see how real data plots, but it should be a good start.

Plots against the old data look almost exactly as they did before, but with slightly different colours for Spring :) 

<img width="1179" height="571" alt="image" src="https://github.com/user-attachments/assets/a035080a-248e-4a3c-9b40-a4d9ac94dd68" />
