### PR TITLE
Only comment with images if images changed.

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,7 +22,19 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           name: images
           path: images
+      - name: Check for changes
+        id: changed
+        run: |
+          # Compare HEAD with previous commit
+          if git diff --quiet HEAD^ HEAD -- .; then
+            echo "No changes."
+            echo "files_changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected."
+            echo "files_changed=true" >> $GITHUB_OUTPUT
+          fi
       - name: Push to temporary branch
+        if: steps.changed.outputs.files_changed == 'true'
         id: push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,10 +47,19 @@ jobs:
           git commit -m "Images for #${{ github.event.number }}"
           git push origin -u pr-images
           echo hash=`git rev-parse HEAD` >> $GITHUB_OUTPUT
-      - name: Update PR status comment
+      - name: Update PR status comment with link
+        if: steps.changed.outputs.files_changed == 'true'
         uses: actions-cool/maintain-one-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             🚀 PR Preview ![generated image](../blob/${{ steps.push.outputs.hash }}/images/spring-quarkus-perf-comparison-latest-throughput-light.svg?raw=true)
+          number: ${{ steps.pr.outputs.id }}
+      - name: Update PR status comment with absense of link
+        if: steps.changed.outputs.files_changed == 'true'
+        uses: actions-cool/maintain-one-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+           This PR does not change any of the images.
           number: ${{ steps.pr.outputs.id }}


### PR DESCRIPTION
```
Run git config user.name github-actions
Switched to branch 'pr-images'
On branch pr-images
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

We want to only comment if there's images anyway, it's just the failure forces us to do that. :) 