### PR TITLE
Improve detection of "no change" case

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Check for changes
         id: changed
         run: |
+          # Refresh index so git diff-index doesn't return true just because of timestamp changes
+          git update-index --refresh
+          
           # Compare HEAD with previous commit
           if ! git diff-index --quiet HEAD --; then 
             echo "Changes detected."


### PR DESCRIPTION
The guard isn't working in the preview action, because git diff is returning true when there are no changes.