### PR TITLE
Strip parentheses from filenames

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -92,7 +92,7 @@ jobs:
           body: |
             🚀 This is what some of the generated images would look like with this change. 
             ![generated throughput image](../blob/${{ steps.hash.outputs.hash }}/images/spring-quarkus-perf-comparison-latest-throughput-light.svg?raw=true)
-            ![generated rss image](../blob/${{ steps.hash.outputs.hash }}/images/spring-quarkus-perf-comparison-latest-memory-(rss)-dark.svg?raw=true)
+            ![generated rss image](../blob/${{ steps.hash.outputs.hash }}/images/spring-quarkus-perf-comparison-latest-memory-rss-dark.svg?raw=true)
           number: ${{ steps.pr.outputs.id }}
       - name: Update PR status comment with absence of link
         if: steps.changed.outputs.files_changed == 'false'

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Benchmark source code: https://github.com/quarkusio/spring-quarkus-perf-comparis
 ![](images/spring-quarkus-perf-comparison/results-latest-boot-and-first-response-time-light.svg#gh-light-mode-only)
 ![](images/spring-quarkus-perf-comparison/results-latest-boot-and-first-response-time-dark.svg#gh-dark-mode-only)
 
-![](images/spring-quarkus-perf-comparison/results-latest-memory-(rss)-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/results-latest-memory-(rss)-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/results-latest-memory-rss-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/results-latest-memory-rss-dark.svg#gh-dark-mode-only)
 
 ![](images/spring-quarkus-perf-comparison/results-latest-build-duration-light.svg#gh-light-mode-only)
 ![](images/spring-quarkus-perf-comparison/results-latest-build-duration-dark.svg#gh-dark-mode-only)

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
@@ -99,14 +99,14 @@ public class GraphicsCommand implements Runnable {
     private void generate(File file, File qualifiedOutputDir,
             TriFunction<String, List<Datapoint>, Config, Chart> chartConstructor,
             BenchmarkData data, PlotDefinition plotDefinition) {
-        String fileMod = plotDefinition.title().toLowerCase().replaceAll(" ", "-").replaceAll("\\+", "and");
         try {
             {
-                File outFile = new File(qualifiedOutputDir, file.getName().replace(".json", "-" + fileMod + "-light.svg"));
+                File outFile = new File(qualifiedOutputDir,
+                        deriveOutputFilename(file, plotDefinition, Theme.LIGHT));
                 generator.generate(chartConstructor, data, plotDefinition, outFile, Theme.LIGHT);
             }
             {
-                File outFile = new File(qualifiedOutputDir, file.getName().replace(".json", "-" + fileMod + "-dark.svg"));
+                File outFile = new File(qualifiedOutputDir, deriveOutputFilename(file, plotDefinition, Theme.DARK));
                 generator.generate(chartConstructor, data, plotDefinition, outFile, Theme.DARK);
             }
         } catch (IOException e) {
@@ -116,5 +116,12 @@ public class GraphicsCommand implements Runnable {
                 throw e;
             }
         }
+    }
+
+    private static String deriveOutputFilename(File file, PlotDefinition plotDefinition, Theme mode) {
+        String chartTitle = plotDefinition.title().toLowerCase().replaceAll(" ", "-").replaceAll("\\+", "and")
+                .replaceAll("\\(", "").replaceAll("\\)", "");
+        return file.getName().replace(".json",
+                "-" + chartTitle + "-" + mode.name() + ".svg");
     }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
@@ -8,12 +8,12 @@ import java.util.Map;
 import io.quarkus.infra.performance.graphics.charts.EmbeddableFont;
 import io.quarkus.infra.performance.graphics.model.Framework;
 
-public record Theme(Color background, Color text, Map<Framework, Color> chartElements) {
+public record Theme(String name, Color background, Color text, Map<Framework, Color> chartElements) {
 
     public static final EmbeddableFont FONT = EmbeddableFont.OPENSANS;
 
-    public static Theme LIGHT = new Theme(
-            Color.WHITE,
+    public static Theme LIGHT = new Theme("light",
+            java.awt.Color.WHITE,
             Color.BLACK,
             Map.ofEntries(
                     Map.entry(Framework.QUARKUS3_JVM, decode("#4695EB")),
@@ -31,7 +31,7 @@ public record Theme(Color background, Color text, Map<Framework, Color> chartEle
                     Map.entry(Framework.SPRING_NATIVE, decode("#2A2A2A")),
                     Map.entry(Framework.SPRING_JVM_AOT, decode("#0E0E0E"))));
 
-    public static final Theme DARK = new Theme(
+    public static final Theme DARK = new Theme("dark",
             Color.BLACK,
             Color.WHITE,
             Map.ofEntries(

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/GraphicsCommandTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/GraphicsCommandTest.java
@@ -129,6 +129,10 @@ public class GraphicsCommandTest {
 
         File image = new File("target/test-output/filename/data-throughput-light.svg");
         assertTrue(image.exists());
+
+        // Check parentheseses are stripped
+        image = new File("target/test-output/filename/data-memory-rss-dark.svg");
+        assertTrue(image.exists());
     }
 
     @Test


### PR DESCRIPTION
I don't love how sensitive the generated filenames are to changes in the title – but I don't want to hardcode filenames, either. I've reduced the sensitivity a bit, and improved the usability of the output names, by stripping parentheses.