### PR TITLE
Fetch and checkout *before* unpacking PR archive

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,6 +15,16 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
+      - name: Set up temporary branch
+        id: branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git fetch origin
+          git branch pr-images || true
+          git checkout pr-images
       - name: Download PR Artifact
         uses: actions/download-artifact@v5
         with:
@@ -42,10 +52,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git branch pr-images || true
-          git checkout pr-images
           git add images/*svg
           git commit -m "Images for #${{ github.event.number }}"
           git push origin -u pr-images


### PR DESCRIPTION
```
Run git config user.name github-actions
Switched to branch 'pr-images'
[pr-images 3341f71] Images for #
 2 files changed, 6060 insertions(+)
 create mode 100644 images/spring-quarkus-perf-comparison-latest-memory-rss-dark.svg
To https://github.com/quarkusio/benchmarks
 create mode 100644 images/spring-quarkus-perf-comparison-latest-memory-rss-light.svg
 ! [rejected]        pr-images -> pr-images (fetch first)
error: failed to push some refs to 'https://github.com/quarkusio/benchmarks'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```