### PR TITLE
Do not put comments into actions shell commands, more diagnostics

### DIFF
--- a/.github/workflows/graphics.yml
+++ b/.github/workflows/graphics.yml
@@ -41,7 +41,7 @@ jobs:
         run: mkdir -p results
       - name: Generate graphics
         run: |
-          rm -rf images # start with a clean slate
+          rm -rf images
           mkdir images
           java -jar graphics-generator/target/quarkus-app/quarkus-run.jar results images true
       - name: Commit generated resources via PR

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,7 +39,7 @@ jobs:
           # Refresh index so git diff-index doesn't return true just because of timestamp changes
           git update-index --refresh
           
-          git status --porcelain
+          git status --long
           
           ls images
           


### PR DESCRIPTION
Apparently # is not the right way to do comments, because cleanup of old files isn't happening.