### PR TITLE
Do not log log files we didn't process

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
@@ -65,8 +65,6 @@ public class GraphicsCommand implements Runnable {
                 if (file.isFile()) {
                     if (file.getName().endsWith(".json")) {
                         processFile(file);
-                    } else {
-                        System.out.printf("Ignoring file %s (unexpected extension)\n", file.getName());
                     }
                 } else if (file.isDirectory()) {
                     processDirectory(file);


### PR DESCRIPTION
There are a lot of log files and listing them all in the logs is annoyingly verbose.