### PR TITLE
Shorten unit name

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/TransactionsPerSecond.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/units/TransactionsPerSecond.java
@@ -8,6 +8,6 @@ public class TransactionsPerSecond extends DimensionalNumber {
 
     @Override
     public String getUnits() {
-        return "transactions/sec";
+        return "tps";
     }
 }


### PR DESCRIPTION
See https://github.com/quarkusio/benchmarks/pull/152#issuecomment-3715241854

I wasn't sure if tps would be clear enough for a non-expert audience but google suggests it's so standard that it should be fine to use.