### PR TITLE
Always reset the PR branch to origin, before checking for changes

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,27 @@ jobs:
           git fetch origin
           git branch --set-upstream-to=origin/pr-images  pr-images || true
           git checkout pr-images
-          git pull origin pr-images --rebase
+          git reset --hard upstream/main
+      - name: Check for changes from the reset
+        id: reset_needed
+        run: |
+          # Decide if any images has changed on this branch
+          if [ -n "$(git status --porcelain images/*svg)" ]; then
+            echo "Changes detected from reset."
+            echo "reset_needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No changes from reset."
+            echo "reset_needed=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Push to temporary branch
+        if: steps.reset_needed.outputs.reset_needed == 'true'
+        id: push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add images/*svg
+          git commit -m "Reset while processing #${{ steps.pr.outputs.id }}"
+          git push origin -u pr-images-reset
       - name: Download PR Artifact
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
At the moment, the preview logic is correctly detecting when images changed, but even if nothing changed, it's reporting a change. I think this is because some files with parentheses are hanging around in the pr-images branch. This PR makes the previewer more aggressive with resetting to a baseline after every build. That would be wasteful if the same PR builds multiple times, but hopefully that's not a very likely scenario. 