### PR TITLE
Force push on preview to make life easy and resolve error

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git add images/*svg
           git commit -m "Reset while processing #${{ steps.pr.outputs.id }}"
-          git push origin -u pr-images-reset
+          git push origin -u pr-images-reset --force
       - name: Download PR Artifact
         uses: actions/download-artifact@v7
         with:
@@ -100,7 +100,7 @@ jobs:
         run: |
           git add images/*svg
           git commit -m "Images for #${{ steps.pr.outputs.id }}"
-          git push origin -u pr-images
+          git push origin -u pr-images --force
       - name: Capture most recent hash on branch
         if: steps.changed.outputs.files_changed == 'true'
         id: hash


### PR DESCRIPTION
```

Run git add images/*svg
[pr-images 7e0029a] Images for #174
 8 files changed, 48 insertions(+), 16 deletions(-)
To https://github.com/quarkusio/benchmarks
 ! [rejected]        pr-images -> pr-images (non-fast-forward)
error: failed to push some refs to 'https://github.com/quarkusio/benchmarks'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

