### PR TITLE
Add deployment workflow for deploy to GitHub pages

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,49 @@
+name: Build and deploy to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: [ "Generate graphics" ]
+    types:
+      - completed
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  assemble:
+    name: Publish all images
+    if: github.repository == 'quarkusio/benchmarks'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        # At some point, the directory size will exceed the 1GB official limit and 10GB unofficial limit, and we will have to be more selective about what's included
+        # (the graphics generator workflow might be where we want to do the discrimination)
+        with:
+          path: ./images/
+
+  # Deploy job
+  deploy:
+    # Add a dependency to the build job
+    needs: assemble
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
https://quarkus.io/benchmarks/ is already live, but it's showing the readme as the landing page, and includes the whole site. We should use a proper publishing workflow to control the content a bit more.