### PR TITLE
Create plots with subsets of data

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -172,7 +172,15 @@ jobs:
           FILES="${{ steps.push.outputs.svgs_changed }}"
           BAR_FILES=$(echo "$FILES" | tr ',' '\n' | grep -v "memory" | head -n2)
           CUBE_FILES=$(echo "$FILES" | tr ',' '\n' | grep "memory" | head -n2)
+          SUBSET_BAR_FILES=$(echo "$FILES" | tr ',' '\n' | grep -v "memory" | grep -v "main" | head -n2)
+          SUBSET_CUBE_FILES=$(echo "$FILES" | tr ',' '\n' | grep "memory" | grep -v "main" | head -n2)
           MD=""
+           for f in $SUBSET_BAR_FILES; do
+            MD="$MD  \n-![$f](../blob/$HASH/$f?raw=true)\n"
+          done
+          for f in $SUBSET_CUBE_FILES; do
+            MD="$MD  \n-![$f](../blob/$HASH/$f?raw=true)\n"
+          done
           for f in $BAR_FILES; do
             MD="$MD  \n-![$f](../blob/$HASH/$f?raw=true)\n"
           done

--- a/README.md
+++ b/README.md
@@ -27,27 +27,42 @@ This diagram shows the architecture & workflow of how the benchmarking executes.
 Benchmark source code: https://github.com/quarkusio/spring-quarkus-perf-comparison
 
 #### Tuned
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-throughput-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-throughput-dark.svg#gh-dark-mode-only)
 
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-boot-and-first-response-time-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-boot-and-first-response-time-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-throughput-for-main-comparison-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-throughput-for-main-comparison-dark.svg#gh-dark-mode-only)
 
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-memory-rss-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-memory-rss-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-boot-and-first-response-time-for-main-comparison-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-boot-and-first-response-time-for-main-comparison-dark.svg#gh-dark-mode-only)
 
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-build-duration-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-build-duration-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-memory-rss-for-main-comparison-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-memory-rss-for-main-comparison-dark.svg#gh-dark-mode-only)
+
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-build-duration-for-main-comparison-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-build-duration-for-main-comparison-dark.svg#gh-dark-mode-only)
+
+### All variations
+
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-throughput-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-throughput-for-all-dark.svg#gh-dark-mode-only)
+
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-boot-and-first-response-time-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-boot-and-first-response-time-for-all-dark.svg#gh-dark-mode-only)
+
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-memory-rss-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-memory-rss-for-all-dark.svg#gh-dark-mode-only)
+
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-build-duration-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/tuned/results-latest-tuned-build-duration-for-all-dark.svg#gh-dark-mode-only)
 
 #### Out of the box
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-throughput-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-throughput-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-throughput-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-throughput-for-all-dark.svg#gh-dark-mode-only)
 
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-boot-and-first-response-time-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-boot-and-first-response-time-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-boot-and-first-response-time-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-boot-and-first-response-time-for-all-dark.svg#gh-dark-mode-only)
 
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-memory-rss-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-memory-rss-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-memory-rss-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-memory-rss-for-all-dark.svg#gh-dark-mode-only)
 
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-build-duration-light.svg#gh-light-mode-only)
-![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-build-duration-dark.svg#gh-dark-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-build-duration-for-all-light.svg#gh-light-mode-only)
+![](images/spring-quarkus-perf-comparison/ootb/results-latest-ootb-build-duration-for-all-dark.svg#gh-dark-mode-only)

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
@@ -8,7 +8,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Optional;
-
 import jakarta.inject.Inject;
 
 import io.quarkus.infra.performance.graphics.charts.BarChart;
@@ -17,129 +16,131 @@ import io.quarkus.infra.performance.graphics.charts.CubeChart;
 import io.quarkus.infra.performance.graphics.charts.Datapoint;
 import io.quarkus.infra.performance.graphics.model.BenchmarkData;
 import io.quarkus.infra.performance.graphics.model.Config;
+import io.quarkus.infra.performance.graphics.model.Group;
 import io.quarkus.infra.performance.graphics.model.Repo;
-
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
 @Command(name = "graphics", mixinStandardHelpOptions = true)
 public class GraphicsCommand implements Runnable {
-  private static final PlotDefinition THROUGHPUT = new PlotDefinition("Throughput", "(Higher is better)", framework -> framework.load().avThroughput());
-  private static final PlotDefinition RSS = new PlotDefinition("Memory (RSS after first request)", "memory-rss", "(Smaller is better)", framework -> framework.rss().avFirstRequestRss());
-  private static final PlotDefinition TIME_TO_FIRST_REQUEST = new PlotDefinition("Boot + First Response Time", "(Lower is better)", framework -> framework.startup().avStartTime());
-  private static final PlotDefinition BUILD_TIME = new PlotDefinition("Build Duration", "(Shorter is better)", framework -> framework.build().avBuildTime());
+    private static final PlotDefinition THROUGHPUT = new PlotDefinition("Throughput", "(Higher is better)", framework -> framework.load().avThroughput());
+    private static final PlotDefinition RSS = new PlotDefinition("Memory (RSS after first request)", "memory-rss", "(Smaller is better)", framework -> framework.rss().avFirstRequestRss());
+    private static final PlotDefinition TIME_TO_FIRST_REQUEST = new PlotDefinition("Boot + First Response Time", "(Lower is better)", framework -> framework.startup().avStartTime());
+    private static final PlotDefinition BUILD_TIME = new PlotDefinition("Build Duration", "(Shorter is better)", framework -> framework.build().avBuildTime());
 
-  @Parameters(paramLabel = "<filename>", defaultValue = "latest.json", description = "A filename of json-formatted data, or a directory. For directories, .json files in the directory will be processed recursively.")
-  Path filename;
+    @Parameters(paramLabel = "<filename>", defaultValue = "latest.json", description = "A filename of json-formatted data, or a directory. For directories, .json files in the directory will be processed recursively.")
+    Path filename;
 
-  @Parameters(paramLabel = "<outputDir>", defaultValue = ".", description = "The directory for generated images")
-  Path outputDirectory;
+    @Parameters(paramLabel = "<outputDir>", defaultValue = ".", description = "The directory for generated images")
+    Path outputDirectory;
 
-  @Parameters(paramLabel = "<tolerateMissingData>", defaultValue = "true", description = "Whether to suppress exceptions caused by missing data")
-  boolean tolerateMissingData;
+    @Parameters(paramLabel = "<tolerateMissingData>", defaultValue = "true", description = "Whether to suppress exceptions caused by missing data")
+    boolean tolerateMissingData;
 
-  @Inject
-  DataIngester ingester;
+    @Inject
+    DataIngester ingester;
 
-  @Inject
-  ImageGenerator generator;
+    @Inject
+    ImageGenerator generator;
 
-  @Override
-  public void run() {
-    try {
-      processPath(filename);
-    }
-    catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private void processPath(Path inputFile) throws IOException {
-    if (Files.isDirectory(inputFile)) {
-      processDirectory(inputFile);
-    }
-    else {
-      processFile(inputFile);
-    }
-  }
-
-  private void processDirectory(Path directory) throws IOException {
-    Files.walkFileTree(directory, new SimpleFileVisitor<>() {
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-          if (file.getFileName().toString().endsWith(".json")) {
-            processFile(file);
-          }
-
-          return FileVisitResult.CONTINUE;
+    @Override
+    public void run() {
+        try {
+            processPath(filename);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-      }
-    );
-  }
+    }
 
-  private void processFile(Path file) {
-    if (Files.isRegularFile(file)) {
-      var data = ingester.ingest(file);
-      var parent = file.getParent();
-      var qualifiedOutputDir = outputDirectory;
-
-      if (parent != null) {
-        var relative = filename.relativize(parent);
-
-        //        If relativize leads to "..", use current dir
-        if (!relative.toString().startsWith("..")) {
-          qualifiedOutputDir = outputDirectory.resolve(relative);
+    private void processPath(Path inputFile) throws IOException {
+        if (Files.isDirectory(inputFile)) {
+            processDirectory(inputFile);
+        } else {
+            processFile(inputFile);
         }
-      }
-
-      if (file.getFileName().toString().contains("latest")) {
-        // https://github.com/quarkusio/benchmarks/issues/203
-        // If the file is a "latest" file, then we want to sub-directory it
-        var scenario = Optional.ofNullable(data.config())
-          .map(Config::repo)
-          .map(Repo::scenario)
-          .orElse(".");
-
-        qualifiedOutputDir = qualifiedOutputDir.resolve(scenario).normalize();
-      }
-
-      generate(file, qualifiedOutputDir, CubeChart::new, data, RSS);
-      generate(file, qualifiedOutputDir, BarChart::new, data, TIME_TO_FIRST_REQUEST);
-      generate(file, qualifiedOutputDir, BarChart::new, data, THROUGHPUT);
-      generate(file, qualifiedOutputDir, BarChart::new, data, BUILD_TIME);
     }
-  }
 
-  private void generate(Path file, Path qualifiedOutputDir, TriFunction<PlotDefinition, List<Datapoint>, BenchmarkData, Chart> chartConstructor, BenchmarkData data, PlotDefinition plotDefinition) {
-    try {
-        var lightFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data.config().repo(), Theme.LIGHT)).toFile();
-        generator.generate(chartConstructor, data, plotDefinition, lightFile, Theme.LIGHT);
+    private void processDirectory(Path directory) throws IOException {
+        Files.walkFileTree(directory, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                        if (file.getFileName().toString().endsWith(".json")) {
+                            processFile(file);
+                        }
 
-        var darkFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data.config().repo(), Theme.DARK)).toFile();
-        generator.generate(chartConstructor, data, plotDefinition, darkFile, Theme.DARK);
+                        return FileVisitResult.CONTINUE;
+                    }
+                }
+        );
     }
-    catch (IOException e) {
-      throw new RuntimeException(e);
+
+    private void processFile(Path file) {
+        if (Files.isRegularFile(file)) {
+            var data = ingester.ingest(file);
+            var parent = file.getParent();
+            var qualifiedOutputDir = outputDirectory;
+
+            if (parent != null) {
+                var relative = filename.relativize(parent);
+
+                //        If relativize leads to "..", use current dir
+                if (! relative.toString().startsWith("..")) {
+                    qualifiedOutputDir = outputDirectory.resolve(relative);
+                }
+            }
+
+            if (file.getFileName().toString().contains("latest")) {
+                // https://github.com/quarkusio/benchmarks/issues/203
+                // If the file is a "latest" file, then we want to sub-directory it
+                var scenario = Optional.ofNullable(data.config())
+                        .map(Config::repo)
+                        .map(Repo::scenario)
+                        .orElse(".");
+
+                qualifiedOutputDir = qualifiedOutputDir.resolve(scenario).normalize();
+            }
+
+            generate(file, qualifiedOutputDir, CubeChart::new, data, RSS);
+            generate(file, qualifiedOutputDir, BarChart::new, data, TIME_TO_FIRST_REQUEST);
+            generate(file, qualifiedOutputDir, BarChart::new, data, THROUGHPUT);
+            generate(file, qualifiedOutputDir, BarChart::new, data, BUILD_TIME);
+        }
     }
-    catch (MissingDataException e) {
-      if (!tolerateMissingData) {
-        throw e;
-      }
+
+    private void generate(Path file, Path qualifiedOutputDir, TriFunction<PlotDefinition, List<Datapoint>, BenchmarkData, Chart> chartConstructor, BenchmarkData allData, PlotDefinition plotDefinition) {
+        for (Group group : Group.values()) {
+            BenchmarkData data = allData.subgroup(group);
+            if (data.results() != null && data.results().size() > 0) {
+                try {
+                    var lightFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data, Theme.LIGHT)).toFile();
+                    generator.generate(chartConstructor, data, plotDefinition, lightFile, Theme.LIGHT);
+
+                    var darkFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data, Theme.DARK)).toFile();
+                    generator.generate(chartConstructor, data, plotDefinition, darkFile, Theme.DARK);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } catch (MissingDataException e) {
+                    if (! tolerateMissingData) {
+                        throw e;
+                    }
+                }
+            }
+        }
     }
-  }
 
-  private static String deriveOutputFilename(Path file, PlotDefinition plotDefinition, Repo repo, Theme mode) {
-    var filename = plotDefinition.filename().toLowerCase()
-      .replaceAll(" ", "-")
-      .replaceAll("\\+", "and")
-      .replaceAll("\\(", "")
-      .replaceAll("\\)", "");
+    private static String deriveOutputFilename(Path file, PlotDefinition plotDefinition, BenchmarkData data, Theme mode) {
+        var filename = plotDefinition.filename().toLowerCase()
+                .replaceAll(" ", "-")
+                .replaceAll("\\+", "and")
+                .replaceAll("\\(", "")
+                .replaceAll("\\)", "");
 
-    var currentFilename = file.getFileName().toString();
+        var currentFilename = file.getFileName().toString();
+        String group = data.group().toString().toLowerCase().replaceAll("_", "-");
 
-    return Optional.ofNullable(repo.scenario())
-      .filter(scenario -> !currentFilename.contains(scenario))
-      .map(scenario -> currentFilename.replace(".json", "-%s-%s-%s.svg".formatted(scenario, filename, mode.name())))
-      .orElseGet(() -> currentFilename.replace(".json", "-%s-%s.svg".formatted(filename, mode.name())));
-  }
+        return Optional.ofNullable(data.config().repo().scenario())
+                .filter(scenario -> ! currentFilename.contains(scenario))
+                .map(scenario -> currentFilename.replace(".json", "-%s-%s-for-%s-%s.svg".formatted(scenario, filename, group, mode.name())))
+                .orElseGet(() -> currentFilename.replace(".json", "-%s-for-%s-%s.svg".formatted(filename, group, mode.name())));
+    }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
@@ -76,7 +76,7 @@ public class CubeChart extends Chart {
 
         int dataPadding = workOutCubeSizes(canvasWithMargins);
 
-        while (dataPadding <= MINIMUM_PADDING_BETWEEN_DATASETS) {
+        while (dataPadding < MINIMUM_PADDING_BETWEEN_DATASETS) {
             // If it doesn't fit, shrink fonts
             for (Cubes c : cubes) {
                 c.decrementFonts();
@@ -108,44 +108,47 @@ public class CubeChart extends Chart {
         int maxColumns = (int) Math.ceil(maxValue / (numCubesPerColumn * unitsPerCube));
 
         int numGutters = data.size() - 1;
-        int gutterPadding = minimumDataPadding * numGutters;
-        int availableWidth = canvasWithMargins.getWidth() - gutterPadding;
+        if (numGutters > 0) {
+            int gutterPadding = minimumDataPadding * numGutters;
+            int availableWidth = canvasWithMargins.getWidth() - gutterPadding;
 
-        int minColumnWidth = availableWidth / (maxColumns * data.size());
-        int widthOfThinSections = 0;
+            int minColumnWidth = availableWidth / (maxColumns * data.size());
+            int widthOfThinSections = 0;
 
-        int smallestCubeSize = Integer.MAX_VALUE;
+            int smallestCubeSize = Integer.MAX_VALUE;
 
-        for (Cubes c : cubes) {
-            // Iterate to a correct value; to start off with, set a column width
-            c.setCubeSize(minColumnWidth);
+            for (Cubes c : cubes) {
+                // Iterate to a correct value; to start off with, set a column width
+                c.setCubeSize(minColumnWidth);
 
-            // Estimate the likely width of a column, assuming evenly spaced sections
-            if (c.getActualHorizontalSize() > c.getColumnCount() * minColumnWidth) {
-                widthOfThinSections += c.getMinimumHorizontalSize();
-                int cubeSizeForThisSection = c.getMinimumHorizontalSize() / c.getColumnCount();
+                // Estimate the likely width of a column, assuming evenly spaced sections
+                if (c.getActualHorizontalSize() > c.getColumnCount() * minColumnWidth) {
+                    widthOfThinSections += c.getMinimumHorizontalSize();
+                    int cubeSizeForThisSection = c.getMinimumHorizontalSize() / c.getColumnCount();
 
-                smallestCubeSize = Math.min(smallestCubeSize, cubeSizeForThisSection);
-            } else {
-                totalColumnsContributingToWidth += c.getColumnCount();
+                    smallestCubeSize = Math.min(smallestCubeSize, cubeSizeForThisSection);
+                } else {
+                    totalColumnsContributingToWidth += c.getColumnCount();
+                }
             }
+
+            int cubeWithPaddingSize = totalColumnsContributingToWidth > 0
+                    ? (availableWidth - widthOfThinSections) / totalColumnsContributingToWidth
+                    :smallestCubeSize;
+            // If no columns go outside the border, then we use the maximum column count and divide it by the average width occupied by captions
+
+            int actualOccupiedArea = 0;
+
+            // Work out how much space is used, so we can space the sections evenly
+            for (Cubes c : cubes) {
+                c.setCubeSize(cubeWithPaddingSize);
+                int width = c.getActualHorizontalSize();
+                actualOccupiedArea += width;
+            }
+
+            return (canvasWithMargins.getWidth() - actualOccupiedArea) / numGutters;
         }
-
-        int cubeWithPaddingSize = totalColumnsContributingToWidth > 0
-                ? (availableWidth - widthOfThinSections) / totalColumnsContributingToWidth
-                :smallestCubeSize;
-        // If no columns go outside the border, then we use the maximum column count and divide it by the average width occupied by captions
-
-        int actualOccupiedArea = 0;
-
-        // Work out how much space is used, so we can space the sections evenly
-        for (Cubes c : cubes) {
-            c.setCubeSize(cubeWithPaddingSize);
-            int width = c.getActualHorizontalSize();
-            actualOccupiedArea += width;
-        }
-
-        return (canvasWithMargins.getWidth() - actualOccupiedArea) / numGutters;
+        return MINIMUM_PADDING_BETWEEN_DATASETS;
     }
 
     @Override

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/BenchmarkData.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/BenchmarkData.java
@@ -1,6 +1,18 @@
 package io.quarkus.infra.performance.graphics.model;
 
 public record BenchmarkData(
-        Timing timing, Results results, Config config) {
+        Timing timing, Results results, Config config, Group group) {
+
+    public BenchmarkData(Timing timing, Results results, Config config) {
+        this(timing, results, config, Group.ALL);
+    }
+
+    public BenchmarkData subgroup(Group group) {
+        return new BenchmarkData(timing, results != null ? results.subgroup(group):null, config, group);
+    }
+
+    public Group group() {
+        return group == null ? Group.ALL:group;
+    }
 
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Category.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Category.java
@@ -1,0 +1,12 @@
+package io.quarkus.infra.performance.graphics.model;
+
+public enum Category {
+    JVM,
+    QUARKUS,
+    NATIVE,
+    AOT,
+    VIRTUAL_THREADS,
+    COMPATIBILITY,
+    SPRING,
+    OLD
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Framework.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Framework.java
@@ -1,41 +1,55 @@
 package io.quarkus.infra.performance.graphics.model;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import static io.quarkus.infra.performance.graphics.model.Category.AOT;
+import static io.quarkus.infra.performance.graphics.model.Category.COMPATIBILITY;
+import static io.quarkus.infra.performance.graphics.model.Category.JVM;
+import static io.quarkus.infra.performance.graphics.model.Category.NATIVE;
+import static io.quarkus.infra.performance.graphics.model.Category.OLD;
+import static io.quarkus.infra.performance.graphics.model.Category.QUARKUS;
+import static io.quarkus.infra.performance.graphics.model.Category.SPRING;
+import static io.quarkus.infra.performance.graphics.model.Category.VIRTUAL_THREADS;
+
+
 public enum Framework {
     // The order of these determines the natural order in the charts
-    QUARKUS3_JVM("quarkus3-jvm", "Quarkus\nJIT (via OpenJDK)"),
-    SPRING4_JVM("spring4-jvm", "Spring 4\nJIT (via OpenJDK)"),
-    SPRING_JVM("spring-jvm", "Spring\nJIT (via OpenJDK)"),
-    SPRING3_JVM("spring3-jvm", "Spring 3\nJIT (via OpenJDK)"),
-    SPRING4_JVM_AOT("spring4-jvm-aot", "Spring 4\nAOT (via OpenJDK)"),
-    SPRING_JVM_AOT("spring-jvm-aot", "Spring\nAOT (via OpenJDK)"),
-    SPRING3_JVM_AOT("spring3-jvm-aot", "Spring 3\nAOT (via OpenJDK)"),
-    QUARKUS3_VIRTUAL("quarkus3-virtual", "Quarkus w/Virtual Threads\nJIT (via OpenJDK)"),
-    SPRING4_VIRTUAL("spring4-virtual", "Spring 4 w/Virtual Threads\nJIT (via OpenJDK)"),
-    SPRING_VIRTUAL("spring-virtual", "Spring w/Virtual Threads\nJIT (via OpenJDK)"),
-    SPRING3_VIRTUAL("spring3-virtual", "Spring 3 w/Virtual Threads\nJIT (via OpenJDK)"),
-    QUARKUS3_NATIVE("quarkus3-native", "Quarkus\nNative (via GraalVM)"),
-    SPRING4_NATIVE("spring4-native", "Spring 4\nNative (via GraalVM)"),
-    SPRING_NATIVE("spring-native", "Spring\nNative (via GraalVM)"),
-    SPRING3_NATIVE("spring3-native", "Spring 3\nNative (via GraalVM)"),
-    QUARKUS3_SPRING_COMPAT("quarkus3-spring-compat", "Quarkus\nwith Spring compatibility libraries"),
-    QUARKUS3_SPRING4_COMPAT("quarkus3-spring4-compat", "Quarkus\nwith Spring 4 compatibility libraries"),
-    QUARKUS3_SPRING3_COMPAT("quarkus3-spring3-compat", "Quarkus\nwith Spring 3 compatibility libraries");
+    QUARKUS3_JVM("quarkus3-jvm", "Quarkus\nJIT (via OpenJDK)", EnumSet.of(QUARKUS, JVM)),
+    SPRING4_JVM("spring4-jvm", "Spring 4\nJIT (via OpenJDK)", EnumSet.of(SPRING, JVM)),
+    SPRING_JVM("spring-jvm", "Spring\nJIT (via OpenJDK)", EnumSet.of(SPRING, JVM)),
+    SPRING3_JVM("spring3-jvm", "Spring 3\nJIT (via OpenJDK)", EnumSet.of(SPRING, JVM, OLD)),
+    SPRING4_JVM_AOT("spring4-jvm-aot", "Spring 4\nAOT (via OpenJDK)", EnumSet.of(SPRING, JVM, AOT)),
+    SPRING_JVM_AOT("spring-jvm-aot", "Spring\nAOT (via OpenJDK)", EnumSet.of(SPRING, JVM, AOT)),
+    SPRING3_JVM_AOT("spring3-jvm-aot", "Spring 3\nAOT (via OpenJDK)", EnumSet.of(SPRING, JVM, AOT, OLD)),
+    QUARKUS3_VIRTUAL("quarkus3-virtual", "Quarkus w/Virtual Threads\nJIT (via OpenJDK)", EnumSet.of(QUARKUS, JVM, VIRTUAL_THREADS)),
+    SPRING4_VIRTUAL("spring4-virtual", "Spring 4 w/Virtual Threads\nJIT (via OpenJDK)", EnumSet.of(SPRING, JVM, VIRTUAL_THREADS)),
+    SPRING_VIRTUAL("spring-virtual", "Spring w/Virtual Threads\nJIT (via OpenJDK)", EnumSet.of(SPRING, JVM, AOT)),
+    SPRING3_VIRTUAL("spring3-virtual", "Spring 3 w/Virtual Threads\nJIT (via OpenJDK)", EnumSet.of(SPRING, JVM, AOT, OLD)),
+    QUARKUS3_NATIVE("quarkus3-native", "Quarkus\nNative (via GraalVM)", EnumSet.of(QUARKUS, NATIVE)),
+    SPRING4_NATIVE("spring4-native", "Spring 4\nNative (via GraalVM)", EnumSet.of(SPRING, NATIVE)),
+    SPRING_NATIVE("spring-native", "Spring\nNative (via GraalVM)", EnumSet.of(SPRING, NATIVE)),
+    SPRING3_NATIVE("spring3-native", "Spring 3\nNative (via GraalVM)", EnumSet.of(SPRING, NATIVE, OLD)),
+    QUARKUS3_SPRING_COMPAT("quarkus3-spring-compat", "Quarkus\nwith Spring compatibility libraries", EnumSet.of(SPRING, COMPATIBILITY, JVM)),
+    QUARKUS3_SPRING4_COMPAT("quarkus3-spring4-compat", "Quarkus\nwith Spring 4 compatibility libraries", EnumSet.of(SPRING, COMPATIBILITY, JVM)),
+    QUARKUS3_SPRING3_COMPAT("quarkus3-spring3-compat", "Quarkus\nwith Spring 3 compatibility libraries", EnumSet.of(SPRING, COMPATIBILITY, JVM, OLD));
 
     private final String name;
     private final String expandedName;
     private static final Map<String, Framework> ENUM_MAP;
+    private final Set<Category> categories;
 
-    Framework(String name, String expandedName) {
+    Framework(String name, String expandedName, Set<Category> categories) {
         this.name = name;
         this.expandedName = expandedName;
+        this.categories = categories;
     }
 
     @JsonValue
@@ -49,8 +63,8 @@ public enum Framework {
 
     // Build an immutable map of String name to enum pairs.
     static {
-      ENUM_MAP = Arrays.stream(values())
-          .collect(Collectors.toUnmodifiableMap(framework -> framework.getName().toLowerCase(), Function.identity()));
+        ENUM_MAP = Arrays.stream(values())
+                .collect(Collectors.toUnmodifiableMap(framework -> framework.getName().toLowerCase(), Function.identity()));
     }
 
     @JsonCreator
@@ -58,4 +72,11 @@ public enum Framework {
         return ENUM_MAP.get(name.toLowerCase());
     }
 
+    public boolean isInGroup(Group group) {
+        return group.contains(this);
+    }
+
+    public boolean hasCategory(Category category) {
+        return categories.contains(category);
+    }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Group.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/model/Group.java
@@ -1,0 +1,96 @@
+package io.quarkus.infra.performance.graphics.model;
+
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static io.quarkus.infra.performance.graphics.model.Category.AOT;
+import static io.quarkus.infra.performance.graphics.model.Category.COMPATIBILITY;
+import static io.quarkus.infra.performance.graphics.model.Category.JVM;
+import static io.quarkus.infra.performance.graphics.model.Category.NATIVE;
+import static io.quarkus.infra.performance.graphics.model.Category.OLD;
+import static io.quarkus.infra.performance.graphics.model.Framework.QUARKUS3_JVM;
+import static io.quarkus.infra.performance.graphics.model.Framework.QUARKUS3_NATIVE;
+import static io.quarkus.infra.performance.graphics.model.Framework.SPRING4_JVM;
+import static io.quarkus.infra.performance.graphics.model.Framework.SPRING4_NATIVE;
+
+public enum Group {
+
+    MAIN_COMPARISON(EnumSet.of(
+            QUARKUS3_JVM, SPRING4_JVM, QUARKUS3_NATIVE, SPRING4_NATIVE
+    ), null),
+
+    AOT_COMPARISON(Set.of(JVM, AOT)),
+
+    JAVA_FRAMEWORKS_WITH_COMPATIBILITY(EnumSet.of(JVM, COMPATIBILITY)),
+
+    QUARKUS(EnumSet.of(
+            Category.QUARKUS
+    )),
+
+    VIRTUAL_THREADS(EnumSet.of(
+            Category.VIRTUAL_THREADS,
+            JVM
+    )),
+
+    JAVA_AND_NATIVE_FRAMEWORKS(EnumSet.noneOf(Framework.class), EnumSet.of(
+            JVM, NATIVE
+    ), EnumSet.of(AOT, Category.VIRTUAL_THREADS)),
+
+    ALL(EnumSet.allOf(Framework.class), null),
+
+    JAVA_AND_NATIVE_AND_AOT_FRAMEWORKS(EnumSet.noneOf(Framework.class), EnumSet.of(
+            NATIVE,
+            AOT,
+            JVM
+    ), EnumSet.of(OLD, Category.VIRTUAL_THREADS));
+
+    private final Set<Framework> frameworks;
+
+    Group(Set<Category> categories) {
+        this(EnumSet.noneOf(Framework.class), categories);
+    }
+
+    Group(EnumSet<Framework> frameworks, Set<Category> categories) {
+        this(frameworks, categories, EnumSet.noneOf(Category.class));
+    }
+
+    /**
+     * Include all the named frameworks and also everything with the named category.
+     */
+    Group(EnumSet<Framework> frameworks, Set<Category> categories, Set<Category> exclusions) {
+        this.frameworks = EnumSet.copyOf(frameworks);
+        if (categories != null) {
+            for (Category category : categories) {
+                for (Framework candidate : Framework.values()) {
+                    if (candidate.hasCategory(category)) {
+                        // Now check the candidate doesn't have any of the exclusions
+                        boolean isExcluded = false;
+                        for (Category exclusion : exclusions) {
+                            if (candidate.hasCategory(exclusion)) {
+                                isExcluded = true;
+                                break;
+                            }
+                        }
+                        if (! isExcluded) {
+                            this.frameworks.add(candidate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public boolean contains(Framework framework) {
+        return frameworks.contains(framework);
+    }
+
+    public boolean containsAny(Category category) {
+        for (Framework f : frameworks) {
+            if (f.hasCategory(category)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/GraphicsCommandTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/GraphicsCommandTest.java
@@ -1,8 +1,5 @@
 package io.quarkus.infra.performance.graphics;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -13,15 +10,17 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.main.Launch;
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusMainTest
 public class GraphicsCommandTest {
@@ -68,27 +67,26 @@ public class GraphicsCommandTest {
     }
 
     private static void deleteDir(Path dir) throws IOException {
-      if (Files.isDirectory(dir)) {
-          Files.walk(dir)
-            .sorted(Comparator.reverseOrder())
-            .forEach(path -> {
-            try {
-              Files.delete(path);
-            }
-            catch (IOException e) {
-              // Eat it and move on
-            }
-          });
+        if (Files.isDirectory(dir)) {
+            Files.walk(dir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            // Eat it and move on
+                        }
+                    });
         }
     }
 
     private static void deleteSvgFiles(Path targetDir) throws IOException {
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(targetDir, "*-light.svg")) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(targetDir, "*-for-all-light.svg")) {
             for (Path file : stream) {
                 Files.deleteIfExists(file);
             }
         }
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(targetDir, "*-dark.svg")) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(targetDir, "*-for-all-dark.svg")) {
             for (Path file : stream) {
                 Files.deleteIfExists(file);
             }
@@ -109,75 +107,83 @@ public class GraphicsCommandTest {
     }
 
     @Test
-    @Launch({ "src/test/resources/data.json", "target/test-output/filename" })
+    @Launch({"src/test/resources/data.json", "target/test-output/filename"})
     public void testLaunchWithFilename(LaunchResult result) {
         String output = result.getOutput();
         assertTrue(output.contains("data.json"), output);
 
-        File image = new File("target/test-output/filename/data-tuned-throughput-light.svg");
+        File image = new File("target/test-output/filename/data-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
+
+        // Check groups
+        image = new File("target/test-output/filename/data-tuned-throughput-for-quarkus-dark.svg");
+        assertTrue(image.exists());
+
+        image = new File("target/test-output/filename/data-tuned-throughput-for-main-comparison-light.svg");
+        assertTrue(image.exists());
+
     }
 
     @Test
-    @Launch({ "tempfile.json", "target/test-output/filename" })
+    @Launch({"tempfile.json", "target/test-output/filename"})
     public void testLaunchWithUnqualifiedFilename(LaunchResult result) {
         String output = result.getOutput();
         assertTrue(output.contains("tempfile.json"), output);
 
-        File image = new File("target/test-output/filename/tempfile-tuned-throughput-light.svg");
+        File image = new File("target/test-output/filename/tempfile-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
     }
 
     @Test
-    @Launch({ "../graphics-generator/src/test/resources/data.json", "target/test-output/filename" })
+    @Launch({"../graphics-generator/src/test/resources/data.json", "target/test-output/filename"})
     public void testLaunchWithRelativeInputFilename(LaunchResult result) {
         String output = result.getOutput();
         assertTrue(output.contains("data.json"), output);
 
-        File image = new File("target/test-output/filename/data-tuned-throughput-light.svg");
+        File image = new File("target/test-output/filename/data-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
     }
 
     @Test
-    @Launch({ "tempfile.json", "../graphics/generator/target/test-output/filename" })
+    @Launch({"tempfile.json", "../graphics/generator/target/test-output/filename"})
     public void testLaunchWithRelativeOutputPath(LaunchResult result) {
         String output = result.getOutput();
         assertTrue(output.contains("tempfile.json"), output);
 
-        File image = new File("target/test-output/filename/data-tuned-throughput-light.svg");
+        File image = new File("target/test-output/filename/data-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
 
         // Check parentheseses are stripped
-        image = new File("target/test-output/filename/data-tuned-memory-rss-dark.svg");
+        image = new File("target/test-output/filename/data-tuned-memory-rss-for-all-dark.svg");
         assertTrue(image.exists());
     }
 
     @Test
-    @Launch({ "src/test/resources", "target/test-output/directory" })
+    @Launch({"src/test/resources", "target/test-output/directory"})
     public void testLaunchWithDirectory(LaunchResult result) {
         String output = result.getOutput();
         assertTrue(output.contains("data.json"), output);
         assertTrue(output.contains("eight-framework.json"), output);
 
         File dir = new File("target/test-output/directory/");
-        File image1 = new File(dir, "data-tuned-throughput-light.svg");
+        File image1 = new File(dir, "data-tuned-throughput-for-all-light.svg");
         assertTrue(image1.exists());
-        File image2 = new File(dir, "eight-framework-tuned-throughput-light.svg");
+        File image2 = new File(dir, "eight-framework-tuned-throughput-for-all-light.svg");
         assertTrue(image2.exists());
 
         File nestedDir = new File("target/test-output/directory/nested/more-nested");
         assertTrue(nestedDir.exists());
-        File image3 = new File(nestedDir, "data3-ootb-throughput-light.svg");
+        File image3 = new File(nestedDir, "data3-ootb-throughput-for-all-light.svg");
         assertTrue(image3.exists());
     }
 
     @Test
-    @Launch({ "src/test/resources/data.json", "target/test-output/filename" })
+    @Launch({"src/test/resources/data.json", "target/test-output/filename"})
     public void testDarkMode(LaunchResult result) {
         String output = result.getOutput();
         assertTrue(output.contains("data.json"), output);
 
-        File image = new File("target/test-output/filename/data-tuned-throughput-dark.svg");
+        File image = new File("target/test-output/filename/data-tuned-throughput-for-all-dark.svg");
         assertTrue(image.exists());
     }
 

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
@@ -1,9 +1,5 @@
 package io.quarkus.infra.performance.graphics;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -11,17 +7,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Function;
-
 import jakarta.inject.Inject;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import io.quarkus.infra.performance.graphics.charts.BarChart;
 import io.quarkus.infra.performance.graphics.model.BenchmarkData;
 import io.quarkus.infra.performance.graphics.model.Config;
 import io.quarkus.infra.performance.graphics.model.Framework;
 import io.quarkus.infra.performance.graphics.model.FrameworkBuild;
+import io.quarkus.infra.performance.graphics.model.Group;
 import io.quarkus.infra.performance.graphics.model.Load;
 import io.quarkus.infra.performance.graphics.model.Repo;
 import io.quarkus.infra.performance.graphics.model.Result;
@@ -29,6 +22,12 @@ import io.quarkus.infra.performance.graphics.model.Results;
 import io.quarkus.infra.performance.graphics.model.units.DimensionalNumber;
 import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 class ImageGeneratorTest {
@@ -55,6 +54,7 @@ class ImageGeneratorTest {
             BenchmarkData data = mock(BenchmarkData.class);
             Results results = new Results();
             when(data.results()).thenReturn(results);
+            when(data.group()).thenReturn(Group.ALL);
             addDatapoint(data, Framework.QUARKUS3_JVM, THROUGHPUT);
             addDatapoint(data, Framework.SPRING3_JVM, 267.87);
             addConfig(data);
@@ -119,7 +119,7 @@ class ImageGeneratorTest {
         String contents = getImageFileContents();
         String font = "sans-serif";
         assertTrue(contents.indexOf(font)
-                        !=contents.lastIndexOf(font),
+                        != contents.lastIndexOf(font),
                 "Fallback font declaration should appear more than once");
     }
 

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/FrameworkTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/FrameworkTest.java
@@ -1,8 +1,10 @@
 package io.quarkus.infra.performance.graphics.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FrameworkTest {
     @Test
@@ -13,6 +15,32 @@ class FrameworkTest {
     @Test
     void getExpandedNameForSimpleSpringCase() {
         assertEquals("Spring 3\nJIT (via OpenJDK)", Framework.SPRING3_JVM.getExpandedName());
+    }
+
+    @Test
+    void getCategories() {
+        assertTrue(Framework.QUARKUS3_JVM.hasCategory(Category.QUARKUS));
+        assertFalse(Framework.SPRING3_JVM.hasCategory(Category.QUARKUS));
+    }
+
+    @Test
+    void isInGroupItIsIn() {
+        assertTrue(Framework.QUARKUS3_VIRTUAL.isInGroup(Group.QUARKUS));
+    }
+
+    @Test
+    void isAlwaysInAllGroup() {
+        assertTrue(Framework.QUARKUS3_VIRTUAL.isInGroup(Group.ALL));
+        assertTrue(Framework.SPRING3_NATIVE.isInGroup(Group.ALL));
+        assertTrue(Framework.SPRING_NATIVE.isInGroup(Group.ALL));
+        assertTrue(Framework.SPRING3_JVM_AOT.isInGroup(Group.ALL));
+        assertTrue(Framework.SPRING4_VIRTUAL.isInGroup(Group.ALL));
+        assertTrue(Framework.QUARKUS3_JVM.isInGroup(Group.ALL));
+    }
+
+    @Test
+    void isInGroupItIsNotIn() {
+        assertFalse(Framework.SPRING3_JVM.isInGroup(Group.QUARKUS));
     }
 
 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/GroupTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/GroupTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.infra.performance.graphics.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GroupTest {
+
+    @Test
+    public void allIncludesEverything() {
+        Group group = Group.ALL;
+        assertNotNull(group);
+        // This isn't an exhaustive test, but it's indicative
+        assertTrue(group.contains(Framework.SPRING4_VIRTUAL));
+        assertTrue(group.contains(Framework.QUARKUS3_JVM));
+        assertTrue(group.contains(Framework.SPRING4_JVM_AOT));
+    }
+
+    // A group constructed by hand
+    @Test
+    public void mainComparisonHasRightEntries() {
+        Group group = Group.MAIN_COMPARISON;
+        assertTrue(group.contains(Framework.QUARKUS3_NATIVE));
+        assertTrue(group.contains(Framework.QUARKUS3_JVM));
+        assertTrue(group.contains(Framework.SPRING4_JVM));
+        assertTrue(group.contains(Framework.SPRING4_NATIVE));
+        assertFalse(group.contains(Framework.QUARKUS3_SPRING4_COMPAT));
+        assertFalse(group.contains(Framework.QUARKUS3_VIRTUAL));
+    }
+
+    // A group constructed using a category
+    @Test
+    public void quarkusIncludesQuarkusButNotSpring() {
+        Group group = Group.QUARKUS;
+        assertTrue(group.contains(Framework.QUARKUS3_NATIVE));
+        assertTrue(group.contains(Framework.QUARKUS3_JVM));
+        assertFalse(group.contains(Framework.SPRING4_JVM));
+    }
+
+    // A group using an exclusion
+    // A group constructed using a category
+    @Test
+    public void javaFrameworksExcludesOlderSpringVersions() {
+        Group group = Group.JAVA_AND_NATIVE_AND_AOT_FRAMEWORKS;
+        assertTrue(group.contains(Framework.QUARKUS3_NATIVE));
+        assertTrue(group.contains(Framework.QUARKUS3_JVM));
+        assertTrue(group.contains(Framework.SPRING4_JVM));
+        assertTrue(group.contains(Framework.SPRING4_JVM_AOT));
+        assertFalse(group.contains(Framework.SPRING4_VIRTUAL));
+        assertFalse(group.contains(Framework.SPRING3_JVM));
+        assertFalse(group.contains(Framework.SPRING3_JVM_AOT));
+    }
+
+    @Test
+    public void categoryChecks() {
+        Group group = Group.JAVA_AND_NATIVE_AND_AOT_FRAMEWORKS;
+        assertTrue(group.containsAny(Category.QUARKUS));
+        assertTrue(group.containsAny(Category.JVM));
+        assertTrue(group.containsAny(Category.NATIVE));
+        assertFalse(group.containsAny(Category.VIRTUAL_THREADS));
+
+
+        group = Group.QUARKUS;
+        assertTrue(group.containsAny(Category.QUARKUS));
+        assertTrue(group.containsAny(Category.JVM));
+        assertTrue(group.containsAny(Category.NATIVE));
+        assertFalse(group.containsAny(Category.SPRING));
+
+    }
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/model/ResultsTest.java
@@ -1,18 +1,17 @@
 package io.quarkus.infra.performance.graphics.model;
 
+import java.util.List;
+
+import io.quarkus.infra.performance.graphics.MissingDataException;
+import io.quarkus.infra.performance.graphics.charts.Datapoint;
+import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.infra.performance.graphics.MissingDataException;
-import io.quarkus.infra.performance.graphics.charts.Datapoint;
-import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
 
 class ResultsTest {
     @Test
@@ -26,7 +25,6 @@ class ResultsTest {
         assertEquals(589.21, datapoints.get(0).value().getValue());
         assertEquals(Framework.QUARKUS3_JVM, datapoints.get(0).framework());
         assertEquals(467.87, datapoints.get(1).value().getValue());
-
     }
 
     @Test
@@ -73,6 +71,20 @@ class ResultsTest {
         assertTrue(exception.getMessage().contains("Rss"), exception.getMessage());
         assertTrue(exception.getMessage().contains("pring"), exception.getMessage());
 
+    }
+
+    @Test
+    void subgroup() {
+        Results results = new Results();
+        addDatapoint(results, Framework.QUARKUS3_JVM, 589.21);
+        addDatapoint(results, Framework.SPRING3_JVM, 467.87);
+        addDatapoint(results, Framework.SPRING4_JVM, 467.87);
+
+        Results subgroup = results.subgroup(Group.MAIN_COMPARISON);
+        List<Datapoint> datapoints = subgroup.getDatasets(f -> f.load().avThroughput());
+        assertEquals(2, datapoints.size());
+        assertEquals(Framework.QUARKUS3_JVM, datapoints.get(0).framework());
+        assertEquals(Framework.SPRING_JVM, datapoints.get(1).framework());
     }
 
     private static void addDatapoint(Results results, Framework framework, Double throughput) {


### PR DESCRIPTION
Resolves #95

Measuring lots of things is good, but showing everything on one plot is a bit overwhelming, and makes it hard for the viewer to focus on the story we're trying to tell. I've created some groupings for subplots which we can use in presentations and web pages to explain different aspects of our performance story.

I've updated the readme to show the new files, and also the preview logic. The preview change won't take effect until after the merge. We should probably also update the readme over on spring-quarkus-perf-comparison to also show one of the more readable plots.

The "with everything" plots should stay basically the same, but with a new name, for example, 

![](https://raw.githubusercontent.com/quarkusio/benchmarks/f87cfe870270eacff7eb95d9ee81deb88998c107/images/tuned/spring-quarkus-perf-comparison-latest-tuned-build-duration-for-all-light.svg)

But we now have subsets too, such as this, which has a similar set of data to what we show on the front page:

![](https://raw.githubusercontent.com/quarkusio/benchmarks/f87cfe870270eacff7eb95d9ee81deb88998c107/images/tuned/spring-quarkus-perf-comparison-latest-tuned-memory-rss-for-main-comparison-dark.svg)

... or this, which shows just the impact of virtual threads:

![](https://raw.githubusercontent.com/quarkusio/benchmarks/f87cfe870270eacff7eb95d9ee81deb88998c107/images/tuned/spring-quarkus-perf-comparison-latest-tuned-throughput-for-virtual-threads-light.svg)

We can add new groups fairly easily.

