### PR TITLE
Default to bold for generic size calculations

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Sizer.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Sizer.java
@@ -43,12 +43,13 @@ public class Sizer {
 
     public static int calculateWidth(Collection<String> strings, int fontSize) {
         String longest = longestString(strings);
-        return calculateWidthNoLineBreaks(longest, fontSize, Font.PLAIN);
+        return calculateWidth(longest, fontSize);
     }
 
     public static int calculateWidth(String string, int fontSize) {
         String longest = longestString(List.of(string.split("\n")));
-        return calculateWidthNoLineBreaks(longest, fontSize, Font.PLAIN);
+        // If we don't know the font, guess bold, because it's better to have too much whitespace than too little
+        return calculateWidthNoLineBreaks(longest, fontSize, Font.BOLD);
     }
 
     public static int calculateWidth(String string, int fontSize, int fontStyle) {
@@ -67,7 +68,7 @@ public class Sizer {
     }
 
     private static Font getFont(int fontSize, int fontStyle) {
-        if (fontStyle==Font.BOLD) {
+        if (fontStyle == Font.BOLD) {
             return boldFonts.computeIfAbsent(fontSize, s -> new Font(Theme.FONT.getName(), Font.BOLD, s));
         } else {
             return fonts.computeIfAbsent(fontSize, s -> new Font(Theme.FONT.getName(), Font.PLAIN, s));

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/SizerTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/SizerTest.java
@@ -1,25 +1,27 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.awt.Font;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SizerTest {
 
     @Test
     void calculateWidthForSingleString() {
         // It's hard to reason about the exact right values here, so hardcode some expectations
-        assertEquals(66, Sizer.calculateWidth("some string", 12));
-        assertEquals(100, Sizer.calculateWidth("some string", 18));
+        assertEquals(70, Sizer.calculateWidth("some string", 12));
+        assertEquals(106, Sizer.calculateWidth("some string", 18));
     }
 
     @Test
     void calculateWidthForSingleStringWithStyle() {
         // It's hard to reason about the exact right values here, so hardcode some expectations
+        assertEquals(66, Sizer.calculateWidth("some string", 12, Font.PLAIN));
         assertEquals(70, Sizer.calculateWidth("some string", 12, Font.BOLD));
+        assertEquals(100, Sizer.calculateWidth("some string", 18, Font.PLAIN));
         assertEquals(106, Sizer.calculateWidth("some string", 18, Font.BOLD));
     }
 


### PR DESCRIPTION
A consequence of adding some bold headings is crowding, especially on the longer headings, like the virtual threads ones. If we don't know what font a string should be, default to guessing bold, because it's better to have too much whitespace than too little. 

For actual layout, we will know the font and use the actual sizes.