### PR TITLE
Align fine print properly

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -86,10 +86,6 @@ public class BarChart extends Chart {
 
         int y = 0;
 
-        int finePrintPadding = 125; // TODO Arbitrary fudge padding, remove when scaling work is done
-        Subcanvas finePrintArea = new Subcanvas(canvasWithMargins, barArea.getWidth() - 2 * finePrintPadding, finePrintHeight,
-                finePrintPadding,
-                barArea.getHeight() + titleCanvas.getHeight());
         canvasWithMargins.setPaint(theme.text());
 
         for (Bar bar : bars) {
@@ -104,7 +100,12 @@ public class BarChart extends Chart {
 
         }
 
-        fineprint.draw(finePrintArea, theme);
+            int finePrintWidth = Math.min(barArea.getWidth(), fineprint.getActualHorizontalSize(finePrintHeight));
+            int finePrintPadding = (barArea.getWidth() - finePrintWidth) / 2;
+            Subcanvas finePrintArea = new Subcanvas(canvasWithMargins, finePrintWidth, finePrintHeight,
+                    finePrintPadding,
+                    barArea.getHeight() + titleCanvas.getHeight());
+            fineprint.draw(finePrintArea, theme);
     }
 
     @Override

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
@@ -16,7 +16,7 @@ public abstract class Chart implements ElasticElement {
 
     protected final List<Datapoint> data;
     protected final Config metadata;
-    // For size calculations, the assumption is that these are stacked vertically
+    // Adding elements into this collection includes them in size calculations. For size calculations, the assumption is that these are stacked vertically
     protected final Set<ElasticElement> children;
     protected final Title title;
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
@@ -69,10 +69,6 @@ public class CubeChart extends Chart {
 
         Subcanvas plotArea = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(),
                 canvasWithMargins.getHeight() - titleCanvas.getHeight() - finePrintHeight, 0, titleCanvas.getHeight());
-        int finePrintPadding = 300; // TODO Arbitrary fudge padding, remove when scaling work is done
-        Subcanvas finePrintArea = new Subcanvas(canvasWithMargins, plotArea.getWidth() - 2 * finePrintPadding, finePrintHeight,
-                finePrintPadding,
-                plotArea.getHeight() + titleCanvas.getHeight());
 
         int dataPadding = workOutCubeSizes(canvasWithMargins);
 
@@ -96,7 +92,12 @@ public class CubeChart extends Chart {
             x += dataArea.getWidth() + dataPadding;
 
         }
-        fineprint.draw(finePrintArea, theme);
+            int finePrintWidth = Math.min(plotArea.getWidth(), fineprint.getActualHorizontalSize(finePrintHeight));
+            int finePrintPadding = (plotArea.getWidth() - finePrintWidth) / 2;
+            Subcanvas finePrintArea = new Subcanvas(canvasWithMargins, finePrintWidth, finePrintHeight,
+                    finePrintPadding,
+                    plotArea.getHeight() + titleCanvas.getHeight());
+            fineprint.draw(finePrintArea, theme);
     }
 
     private int workOutCubeSizes(Subcanvas canvasWithMargins) {
@@ -115,7 +116,7 @@ public class CubeChart extends Chart {
             int minColumnWidth = availableWidth / (maxColumns * data.size());
             int widthOfThinSections = 0;
 
-            int smallestCubeSize = Integer.MAX_VALUE;
+            int smallestCubeSize = canvasWithMargins.getHeight();
 
             for (Cubes c : cubes) {
                 // Iterate to a correct value; to start off with, set a column width

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
@@ -87,6 +87,7 @@ public class Cubes implements ElasticElement {
 
         Subcanvas labelArea = new Subcanvas(dataArea, dataArea.getWidth(), dataArea.getHeight() - cubeArea.getHeight(), 0,
                 cubeArea.getHeight());
+        System.out.println();
 
         int startingY = cubeArea.getHeight() - totalCubeSize;
 
@@ -98,7 +99,7 @@ public class Cubes implements ElasticElement {
         for (int i = 0; i < numCubes; i++) {
             cubeArea.fillRect(cx, cy, cubeSize, cubeSize);
             cy -= totalCubeSize;
-            if ((i + 1) % numCubesPerColumn==0) {
+            if ((i + 1) % numCubesPerColumn == 0) {
                 cx += totalCubeSize;
                 cy = startingY;
             }
@@ -106,9 +107,9 @@ public class Cubes implements ElasticElement {
         }
 
         labelArea.setPaint(theme.text());
-        int labelY = 0;
         frameworkLabel.draw(labelArea, labelArea.getWidth() / 2, 0);
-        valueLabel.draw(labelArea, labelArea.getWidth() / 2, labelY + LABEL_HEIGHT);
+        // If we have extra space, leave it at the the bottom, rather than awkwardly between the two labels
+        valueLabel.draw(labelArea, labelArea.getWidth() / 2, frameworkLabel.getActualHeight());
     }
 
     // Includes the padding

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
@@ -19,7 +19,6 @@ public class Label {
     private DelimitedStyles styles = new DelimitedStyles(new int[]{Font.PLAIN}, LINE_BREAK);
     private Alignment alignment = Alignment.LEFT;
     private VAlignment valignment = VAlignment.MIDDLE;
-    private int lineHeight;
     private FontMetrics fontMetrics;
     private Font baseFont;
     private Font[] fonts;
@@ -52,16 +51,16 @@ public class Label {
 
         // Should be the same as the targetHeight, but recalculate in case of rounding errors
         fontMetrics = g.getGraphics().getFontMetrics();
-        lineHeight = (int) (fontMetrics.getHeight() * lineSpacing);
+        int lineHeight = (int) (fontMetrics.getHeight() * lineSpacing);
         int textBlockHeight = lineHeight * strings.length;
 
         // Compute starting y to vertically center the text block
         int yPosition = switch (valignment) {
-            case TOP -> y + g.getGraphics().getFontMetrics().getAscent();
-            case BOTTOM -> y - getAscent();
-            case MIDDLE -> y - textBlockHeight / 2 + getAscent();
+            case TOP -> y + fontMetrics.getAscent();
+            case BOTTOM -> y;
+            case MIDDLE -> y - textBlockHeight / 2 + fontMetrics.getAscent();
         };
-
+        
         for (int i = 0; i < strings.length; i++) {
 
             String string = strings[i];
@@ -170,7 +169,11 @@ public class Label {
     }
 
     public int getLineHeight() {
-        return lineHeight;
+        if (fontMetrics != null) {
+            return fontMetrics.getHeight();
+        } else {
+            return baseFont.getSize();
+        }
     }
 
     public int calculateWidth(String s) {
@@ -179,6 +182,11 @@ public class Label {
         } else {
             return Sizer.calculateWidth(s, baseFont.getSize());
         }
+    }
+
+
+    public int getActualHeight() {
+        return (int) (strings.length * lineSpacing * getLineHeight());
     }
 
     public int getDescent() {

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
@@ -45,7 +45,7 @@ public abstract class ChartTest {
 
     }
 
-    private static PlotDefinition createPlotDefinition() {
+    protected PlotDefinition createPlotDefinition() {
         Function<Result, ? extends DimensionalNumber> fun = framework -> framework.load().avThroughput();
         PlotDefinition plotDefinition = new PlotDefinition("test plot", "some subtitle", fun);
         return plotDefinition;


### PR DESCRIPTION
This fixes a todo in the charts, which had been manually centering the fine print element. 
I also noticed that bottom text alignment was broken, so I fixed that.