### PR TITLE
Add more tests and sense checks on subcanvas creation

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -100,12 +100,7 @@ public class BarChart extends Chart {
 
         }
 
-            int finePrintWidth = Math.min(barArea.getWidth(), fineprint.getActualHorizontalSize(finePrintHeight));
-            int finePrintPadding = (barArea.getWidth() - finePrintWidth) / 2;
-            Subcanvas finePrintArea = new Subcanvas(canvasWithMargins, finePrintWidth, finePrintHeight,
-                    finePrintPadding,
-                    barArea.getHeight() + titleCanvas.getHeight());
-            fineprint.draw(finePrintArea, theme);
+        drawFinePrint(canvasWithMargins, theme, finePrintHeight, barArea.getHeight() + titleCanvas.getHeight(), fineprint);
     }
 
     @Override

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
@@ -38,11 +38,11 @@ public abstract class Chart implements ElasticElement {
 
     public void draw(Subcanvas g, Theme theme) {
         if (getMinimumHorizontalSize() > g.getWidth()) {
-            throw new SizeException("Cannot fit " + getMinimumHorizontalSize() + "px of content into a " + g.getHeight()
+            throw new SizeException("Cannot fit " + getMinimumHorizontalSize() + "px of content into a " + g.getWidth()
                     + "px horizontal space.");
         }
         if (getMinimumVerticalSize() > g.getHeight()) {
-            throw new SizeException("Cannot fit " + getMinimumHorizontalSize() + "px of content into a " + g.getHeight()
+            throw new SizeException("Cannot fit " + getMinimumVerticalSize() + "px of content into a " + g.getHeight()
                     + "px vertical space.");
         }
 
@@ -59,6 +59,13 @@ public abstract class Chart implements ElasticElement {
     }
 
     protected abstract void drawNoCheck(Subcanvas g, Theme theme);
+
+    protected static void drawFinePrint(Subcanvas canvasWithMargins, Theme theme, int finePrintHeight, int yOffset, FinePrint fineprint) {
+        int finePrintWidth = Math.min(canvasWithMargins.getWidth(), fineprint.getActualHorizontalSize(finePrintHeight));
+        int finePrintPadding = (canvasWithMargins.getWidth() - finePrintWidth) / 2;
+        Subcanvas finePrintArea = new Subcanvas(canvasWithMargins, finePrintWidth, finePrintHeight, finePrintPadding, yOffset);
+        fineprint.draw(finePrintArea, theme);
+    }
 
     // SVGs after to be done *after* the main drawing, because getting the document root before drawing causes all subsequent draws to be dropped.
     // This seems to be a characteristic of the Batik streaming model.

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
@@ -18,6 +18,8 @@ public class Cubes implements ElasticElement {
     private final Label valueLabel;
     private final Label frameworkLabel;
     private static final int MINIMUM_CUBE_SIZE = 2;
+    private static final int MINIMUM_FONT_SIZE = 8;
+    private static final int MAXIMUM_FONT_SIZE = 24;
     private static int maximumCubeSize = 20;
 
     public Cubes(Datapoint d) {
@@ -51,7 +53,9 @@ public class Cubes implements ElasticElement {
 
     @Override
     public int getMaximumHorizontalSize() {
-        return (int) Math.ceil(d.value().getValue() / numCubesPerColumn * maximumCubeSize);
+        int cubesWidth = (int) Math.ceil(d.value().getValue() / numCubesPerColumn * maximumCubeSize);
+        double widestLabel = Math.max(valueLabel.calculateWidth(MAXIMUM_FONT_SIZE), frameworkLabel.calculateWidth(MAXIMUM_FONT_SIZE));
+        return (int) Math.max(widestLabel, cubesWidth);
     }
 
     @Override
@@ -62,14 +66,13 @@ public class Cubes implements ElasticElement {
 
     @Override
     public int getMinimumHorizontalSize() {
-        // Assume we can shrink columns smaller than the label
-        int widestLabel = Math.max(valueLabel.calculateWidth(), frameworkLabel.calculateWidth());
+
+        double widestLabel = Math.max(valueLabel.calculateWidth(MINIMUM_FONT_SIZE), frameworkLabel.calculateWidth(MINIMUM_FONT_SIZE));
         int cubesWidth = (int) Math.ceil(d.value().getValue() / numCubesPerColumn * MINIMUM_CUBE_SIZE);
-        return Math.max(widestLabel, cubesWidth);
+        return (int) Math.max(widestLabel, cubesWidth);
     }
 
     public int getActualHorizontalSize() {
-        // Assume we can shrink columns smaller than the label
         int widestLabel = Math.max(valueLabel.calculateWidth(), frameworkLabel.calculateWidth());
         int cubesWidth = (int) Math.ceil(d.value().getValue() / numCubesPerColumn * totalCubeSize);
         return Math.max(widestLabel, cubesWidth);
@@ -87,7 +90,6 @@ public class Cubes implements ElasticElement {
 
         Subcanvas labelArea = new Subcanvas(dataArea, dataArea.getWidth(), dataArea.getHeight() - cubeArea.getHeight(), 0,
                 cubeArea.getHeight());
-        System.out.println();
 
         int startingY = cubeArea.getHeight() - totalCubeSize;
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
@@ -60,7 +60,7 @@ public class Label {
             case BOTTOM -> y;
             case MIDDLE -> y - textBlockHeight / 2 + fontMetrics.getAscent();
         };
-        
+
         for (int i = 0; i < strings.length; i++) {
 
             String string = strings[i];
@@ -202,6 +202,13 @@ public class Label {
         return Sizer.calculateWidth(longestText, font);
     }
 
+
+    public double calculateWidth(int fontSize) {
+        String longestText = getLongestText();
+        return Sizer.calculateWidth(longestText, fontSize);
+    }
+
+
     private String getLongestText() {
         // It would be cheaper to just count characters, but sometimes the longest string isn't the fattest – including for framework labels we are using
         return Arrays.stream(strings).max(Comparator.comparingInt(this::calculateWidth)).orElse("");
@@ -210,6 +217,7 @@ public class Label {
     public String toString() {
         return "Label[" + getLongestText() + "]";
     }
+
 
     private record DelimitedStyles(int[] styles, String delimiter) {
     }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Subcanvas.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Subcanvas.java
@@ -35,6 +35,13 @@ public class Subcanvas {
         this.xOffset = subcanvas.xOffset + xOffset;
         this.yOffset = subcanvas.yOffset + yOffset;
 
+        if (height < 0) {
+            throw new IllegalArgumentException("Cannot construct a canvas with negative height: " + height);
+        }
+        if (width < 0) {
+            throw new IllegalArgumentException("Cannot construct a canvas with negative width: " + width);
+        }
+
         if (debug) {
             debugBorders();
         }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import java.awt.Dimension;
 import java.util.Random;
 import java.util.function.Function;
 
@@ -17,21 +16,66 @@ import io.quarkus.infra.performance.graphics.model.Result;
 import io.quarkus.infra.performance.graphics.model.Results;
 import io.quarkus.infra.performance.graphics.model.units.DimensionalNumber;
 import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
-import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.svggen.SVGGraphics2D;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.DOMImplementation;
-import org.w3c.dom.Document;
 
-import static org.apache.batik.util.SVGConstants.SVG_NAMESPACE_URI;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public abstract class ChartTest {
+public abstract class ChartTest extends ElasticElementTest {
 
     @Test
-    public void testCanDrawInMinimumDimensions() {
-        BenchmarkData data = mockBenchmarkData();
+    public void testBoundsOnDimensionsForSmallGroup() {
+        BenchmarkData data = mockBenchmarkData(2);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int preferredWidth = chart.getPreferredHorizontalSize();
+        int preferredHeight = chart.getPreferredVerticalSize();
+
+        int minimumWidth = chart.getMinimumHorizontalSize();
+        int minimumHeight = chart.getMinimumVerticalSize();
+
+        int maximumWidth = chart.getMaximumHorizontalSize();
+        int maximumHeight = chart.getMaximumVerticalSize();
+
+        assertTrue(preferredWidth <= maximumWidth, preferredWidth + " > " + maximumWidth);
+        assertTrue(preferredWidth >= minimumWidth, preferredWidth + " > " + minimumWidth);
+
+        assertTrue(preferredHeight <= maximumHeight, preferredHeight + " > " + maximumHeight);
+        assertTrue(preferredHeight >= minimumHeight, preferredHeight + " > " + minimumHeight);
+
+    }
+
+    @Test
+    public void testBoundsOnDimensionsForLargeGroup() {
+        BenchmarkData data = mockBenchmarkData(Framework.values().length);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int preferredWidth = chart.getPreferredHorizontalSize();
+        int preferredHeight = chart.getPreferredVerticalSize();
+
+        int minimumWidth = chart.getMinimumHorizontalSize();
+        int minimumHeight = chart.getMinimumVerticalSize();
+
+        int maximumWidth = chart.getMaximumHorizontalSize();
+        int maximumHeight = chart.getMaximumVerticalSize();
+
+        assertTrue(preferredWidth <= maximumWidth, preferredWidth + " > " + maximumWidth);
+        assertTrue(preferredWidth >= minimumWidth, preferredWidth + " > " + minimumWidth);
+
+        assertTrue(preferredHeight <= maximumHeight, preferredHeight + " > " + maximumHeight);
+        assertTrue(preferredHeight >= minimumHeight, preferredHeight + " > " + minimumHeight);
+
+    }
+
+    @Test
+    public void testCanDrawSmallGroupInMinimumDimensions() {
+        BenchmarkData data = mockBenchmarkData(3);
         PlotDefinition plotDefinition = createPlotDefinition();
 
         Chart chart = createChart(plotDefinition, data);
@@ -42,7 +86,81 @@ public abstract class ChartTest {
         SVGGraphics2D svgGenerator = getSvgGraphics2D(minWidth, minHeight);
         Theme theme = Theme.DARK;
         chart.draw(new Subcanvas(svgGenerator), theme);
+    }
 
+    @Test
+    public void testCanDrawLargeGroupInMinimumDimensions() {
+        BenchmarkData data = mockBenchmarkData(Framework.values().length);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int minHeight = chart.getMinimumVerticalSize();
+        int minWidth = chart.getMinimumHorizontalSize();
+
+        SVGGraphics2D svgGenerator = getSvgGraphics2D(minWidth, minHeight);
+        Theme theme = Theme.DARK;
+        chart.draw(new Subcanvas(svgGenerator), theme);
+    }
+
+    @Test
+    public void testCanDrawSmallGroupInPreferredDimensions() {
+        BenchmarkData data = mockBenchmarkData(3);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int width = chart.getPreferredHorizontalSize();
+        int height = chart.getPreferredVerticalSize();
+
+        SVGGraphics2D svgGenerator = getSvgGraphics2D(width, height);
+        Theme theme = Theme.LIGHT;
+        chart.draw(new Subcanvas(svgGenerator), theme);
+    }
+
+    @Test
+    public void testCanDrawLargeGroupInPreferredDimensions() {
+        BenchmarkData data = mockBenchmarkData(Framework.values().length);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int width = chart.getPreferredHorizontalSize();
+        int height = chart.getPreferredVerticalSize();
+
+        SVGGraphics2D svgGenerator = getSvgGraphics2D(width, height);
+        Theme theme = Theme.LIGHT;
+        chart.draw(new Subcanvas(svgGenerator), theme);
+    }
+
+    @Test
+    public void testCanDrawSoloGroupInPreferredDimensions() {
+        BenchmarkData data = mockBenchmarkData(1);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int width = chart.getPreferredHorizontalSize();
+        int height = chart.getPreferredVerticalSize();
+
+        SVGGraphics2D svgGenerator = getSvgGraphics2D(width, height);
+        Theme theme = Theme.LIGHT;
+        chart.draw(new Subcanvas(svgGenerator), theme);
+    }
+
+    @Test
+    public void testCanDrawEmptyGroupInPreferredDimensions() {
+        BenchmarkData data = mockBenchmarkData(0);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int width = chart.getPreferredHorizontalSize();
+        int height = chart.getPreferredVerticalSize();
+
+        SVGGraphics2D svgGenerator = getSvgGraphics2D(width, height);
+        Theme theme = Theme.LIGHT;
+        chart.draw(new Subcanvas(svgGenerator), theme);
     }
 
     protected PlotDefinition createPlotDefinition() {
@@ -52,12 +170,17 @@ public abstract class ChartTest {
     }
 
     private static BenchmarkData mockBenchmarkData() {
+        return mockBenchmarkData(4);
+    }
+
+    private static BenchmarkData mockBenchmarkData(int count) {
         BenchmarkData data = mock(BenchmarkData.class);
         Results results = new Results();
         when(data.results()).thenReturn(results);
         when(data.group()).thenReturn(Group.ALL);
-        addDatapoint(data, Framework.QUARKUS3_JVM, (double) new Random().nextInt());
-        addDatapoint(data, Framework.SPRING3_JVM, 267.87);
+        for (int i = 0; i < count; i++) {
+            addDatapoint(data, Framework.values()[i], (double) new Random().nextInt(400));
+        }
         addConfig(data);
         return data;
     }
@@ -83,14 +206,6 @@ public abstract class ChartTest {
         chart.draw(new Subcanvas(svgGenerator), theme);
     }
 
-    protected static SVGGraphics2D getSvgGraphics2D(int width, int height) {
-        DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
-        Document doc = impl.createDocument(SVG_NAMESPACE_URI, "svg", null);
-
-        SVGGraphics2D svgGenerator = new SVGGraphics2D(doc);
-        svgGenerator.setSVGCanvasSize(new Dimension(width, height));
-        return svgGenerator;
-    }
 
     protected abstract Chart createChart(PlotDefinition plotDefinition, BenchmarkData data);
 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubeChartTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubeChartTest.java
@@ -2,12 +2,42 @@ package io.quarkus.infra.performance.graphics.charts;
 
 import io.quarkus.infra.performance.graphics.PlotDefinition;
 import io.quarkus.infra.performance.graphics.model.BenchmarkData;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class CubeChartTest extends ChartTest {
 
     @Override
     protected CubeChart createChart(PlotDefinition plotDefinition, BenchmarkData data) {
         return new CubeChart(plotDefinition, data.results().getDatasets(plotDefinition.fun()), data);
+    }
+
+    @Override
+    @Disabled
+    @Test
+    public void testCanDrawSmallGroupInMinimumDimensions() {
+
+    }
+
+    @Override
+    @Disabled
+    @Test
+    public void testCanDrawLargeGroupInMinimumDimensions() {
+
+    }
+
+    @Override
+    @Disabled
+    @Test
+    public void testCanDrawLargeGroupInPreferredDimensions() {
+
+    }
+
+    @Override
+    @Disabled
+    @Test
+    public void testCanDrawEmptyGroupInPreferredDimensions() {
+
     }
 
 

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubesTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubesTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+import java.util.Random;
+
+import io.quarkus.infra.performance.graphics.model.Framework;
+import io.quarkus.infra.performance.graphics.model.units.Memory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CubesTest {
+
+    @Test
+    public void testBoundsOnDimensionsForFrameworkWithShortNameAndHighValue() {
+        Memory m = new Memory(315);
+        Datapoint d = new Datapoint(Framework.SPRING3_JVM, m);
+
+        Cubes chart = new Cubes(d);
+
+        int preferredWidth = chart.getPreferredHorizontalSize();
+        int preferredHeight = chart.getPreferredVerticalSize();
+
+        int minimumWidth = chart.getMinimumHorizontalSize();
+        int minimumHeight = chart.getMinimumVerticalSize();
+
+        int maximumWidth = chart.getMaximumHorizontalSize();
+        int maximumHeight = chart.getMaximumVerticalSize();
+
+        assertTrue(preferredWidth <= maximumWidth, preferredWidth + " > " + maximumWidth);
+        assertTrue(preferredWidth >= minimumWidth, preferredWidth + " > " + minimumWidth);
+
+        assertTrue(preferredHeight <= maximumHeight, preferredHeight + " > " + maximumHeight);
+        assertTrue(preferredHeight >= minimumHeight, preferredHeight + " > " + minimumHeight);
+    }
+
+    @Test
+    public void testBoundsOnDimensionsForFrameworkWithLongNameAndLowValue() {
+        Memory m = new Memory(70);
+        Datapoint d = new Datapoint(Framework.QUARKUS3_VIRTUAL, m);
+
+        Cubes chart = new Cubes(d);
+
+        int preferredWidth = chart.getPreferredHorizontalSize();
+        int preferredHeight = chart.getPreferredVerticalSize();
+
+        int minimumWidth = chart.getMinimumHorizontalSize();
+        int minimumHeight = chart.getMinimumVerticalSize();
+
+        int maximumWidth = chart.getMaximumHorizontalSize();
+        int maximumHeight = chart.getMaximumVerticalSize();
+
+        assertTrue(preferredWidth <= maximumWidth, preferredWidth + " > " + maximumWidth);
+        assertTrue(preferredWidth >= minimumWidth, preferredWidth + " > " + minimumWidth);
+
+        assertTrue(preferredHeight <= maximumHeight, preferredHeight + " > " + maximumHeight);
+        assertTrue(preferredHeight >= minimumHeight, preferredHeight + " > " + minimumHeight);
+    }
+
+    private static Memory getRandomMemory() {
+        return new Memory(new Random().nextDouble() * 1000);
+    }
+
+}

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ElasticElementTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ElasticElementTest.java
@@ -1,38 +1,45 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
+import java.awt.Dimension;
 import java.io.StringWriter;
 
+import io.quarkus.infra.performance.graphics.Theme;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.svggen.SVGGraphics2D;
 import org.apache.batik.svggen.SVGGraphics2DIOException;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 
-import io.quarkus.infra.performance.graphics.Theme;
+import static org.apache.batik.util.SVGConstants.SVG_NAMESPACE_URI;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ElasticElementTest {
-  protected static final String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
+    protected static final String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
 
-  protected String drawSvg(ElasticElement e) {
-    DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
-    Document doc = impl.createDocument(svgNS, "svg", null);
+    protected String drawSvg(ElasticElement e) {
 
-    SVGGraphics2D g = new SVGGraphics2D(doc);
+        SVGGraphics2D g = getSvgGraphics2D(e.getPreferredHorizontalSize(), e.getPreferredVerticalSize());
 
-    e.draw(new Subcanvas(g, 900, 900, 0, 0), Theme.DARK);
+        e.draw(new Subcanvas(g, e.getPreferredHorizontalSize(), e.getPreferredVerticalSize(), 0, 0), Theme.DARK);
 
-    StringWriter writer = new StringWriter();
-    try {
-      g.stream(writer, true);
+        StringWriter writer = new StringWriter();
+        try {
+            g.stream(writer, true);
+        } catch (SVGGraphics2DIOException ex) {
+            fail(ex);
+        }
+
+        String svgString = writer.toString();
+        return svgString;
+
     }
-    catch (SVGGraphics2DIOException ex) {
-      fail(ex);
+
+    protected static SVGGraphics2D getSvgGraphics2D(int width, int height) {
+        DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
+        Document doc = impl.createDocument(SVG_NAMESPACE_URI, "svg", null);
+
+        SVGGraphics2D svgGenerator = new SVGGraphics2D(doc);
+        svgGenerator.setSVGCanvasSize(new Dimension(width, height));
+        return svgGenerator;
     }
-
-    String svgString = writer.toString();
-    return svgString;
-
-  }
 }


### PR DESCRIPTION
The work on the composite graphs is exposing a bunch of areas where some charts don't fit into the bounds they're given. This PR adds more tests to do things like ensure the minimum requested size is less than the maximum requested size for all components. (You'd think that would be obviously true, but I hit cases where it wasn't.)

It also fails fast if we try to create a canvas with negative dimensions. 

I couldn't actually get the new tests passing for the CubeChart, but fixing that will need a bigger rewrite of the CubeChart layout algorithm, so I will do that in another PR. 