### PR TITLE
Improve clarity and quality of cube layout algorithm

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeGroup.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeGroup.java
@@ -1,0 +1,36 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+public class CubeGroup {
+    private int numCubesPerColumn = 16;
+    private int unitsPerCube = 1; // For now, assume 1mb per square
+    private int totalCubeSize;
+
+    public void setNumCubesPerColumn(int n) {
+        this.numCubesPerColumn = n;
+    }
+
+    public int getNumCubesPerColumn() {
+        return numCubesPerColumn;
+    }
+
+    public double getUnitsPerCube() {
+        return unitsPerCube;
+    }
+
+    public void setUnitsPerCube(int unitsPerCube) {
+        this.unitsPerCube = unitsPerCube;
+    }
+
+    // The property including padding
+    public int getTotalCubeSize() {
+        return totalCubeSize;
+    }
+
+    public void setTotalCubeSize(int totalCubeSize) {
+        this.totalCubeSize = totalCubeSize;
+    }
+
+    public void decrementTotalCubeSize() {
+        this.totalCubeSize -= 1;
+    }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
@@ -11,19 +11,18 @@ public class Cubes implements ElasticElement {
     private static final int LABEL_HEIGHT = BAR_THICKNESS;
     public static final double DECREMENT_INCREMENT = 0.97;
     private final Datapoint d;
-    private static int numCubesPerColumn = 16;
     private static final int CUBE_PADDING = 1;
-    private final int unitsPerCube = 1; // For now, assume 1mb per square
-    private int totalCubeSize;
     private final Label valueLabel;
     private final Label frameworkLabel;
     private static final int MINIMUM_CUBE_SIZE = 2;
     private static final int MINIMUM_FONT_SIZE = 8;
     private static final int MAXIMUM_FONT_SIZE = 24;
-    private static int maximumCubeSize = 20;
+    static final int MAXIMUM_CUBE_SIZE = 20;
+    private final CubeGroup cubeGroup;
 
-    public Cubes(Datapoint d) {
+    public Cubes(Datapoint d, CubeGroup cubeGroup) {
         this.d = d;
+        this.cubeGroup = cubeGroup;
         double val = d.value().getValue();
 
         frameworkLabel = new Label(d.framework().getExpandedName())
@@ -37,30 +36,22 @@ public class Cubes implements ElasticElement {
                 .setStyle(Font.BOLD).setTargetHeight(LABEL_HEIGHT * 2 / 3);
     }
 
-    public static void setNumCubesPerColumn(int num) {
-        numCubesPerColumn = num;
-    }
-
-    public static void setMaxCubeSize(int m) {
-        maximumCubeSize = m;
-    }
-
     @Override
     public int getMaximumVerticalSize() {
-        return (int) Math.min(numCubesPerColumn, d.value().getValue()) * maximumCubeSize + valueLabel.getTargetHeight()
+        return (int) Math.min(cubeGroup.getNumCubesPerColumn(), d.value().getValue()) * MAXIMUM_CUBE_SIZE + valueLabel.getTargetHeight()
                 + frameworkLabel.getTargetHeight();
     }
 
     @Override
     public int getMaximumHorizontalSize() {
-        int cubesWidth = (int) Math.ceil(d.value().getValue() / numCubesPerColumn * maximumCubeSize);
+        int cubesWidth = (int) Math.ceil(d.value().getValue() / cubeGroup.getNumCubesPerColumn() * MAXIMUM_CUBE_SIZE);
         double widestLabel = Math.max(valueLabel.calculateWidth(MAXIMUM_FONT_SIZE), frameworkLabel.calculateWidth(MAXIMUM_FONT_SIZE));
         return (int) Math.max(widestLabel, cubesWidth);
     }
 
     @Override
     public int getMinimumVerticalSize() {
-        return (int) Math.min(numCubesPerColumn, d.value().getValue()) * MINIMUM_CUBE_SIZE + valueLabel.getTargetHeight()
+        return (int) Math.min(cubeGroup.getNumCubesPerColumn(), d.value().getValue()) * MINIMUM_CUBE_SIZE + valueLabel.getTargetHeight()
                 + frameworkLabel.getTargetHeight();
     }
 
@@ -68,15 +59,34 @@ public class Cubes implements ElasticElement {
     public int getMinimumHorizontalSize() {
 
         double widestLabel = Math.max(valueLabel.calculateWidth(MINIMUM_FONT_SIZE), frameworkLabel.calculateWidth(MINIMUM_FONT_SIZE));
-        int cubesWidth = (int) Math.ceil(d.value().getValue() / numCubesPerColumn * MINIMUM_CUBE_SIZE);
+        int cubesWidth = (int) Math.ceil(d.value().getValue() / cubeGroup.getNumCubesPerColumn() * MINIMUM_CUBE_SIZE);
         return (int) Math.max(widestLabel, cubesWidth);
     }
 
+
+    public int getTextWidth() {
+        return Math.max(valueLabel.calculateWidth(), frameworkLabel.calculateWidth());
+    }
+
     public int getActualHorizontalSize() {
-        int widestLabel = Math.max(valueLabel.calculateWidth(), frameworkLabel.calculateWidth());
-        int cubesWidth = (int) Math.ceil(d.value().getValue() / numCubesPerColumn * totalCubeSize);
+        int widestLabel = getTextWidth();
+        int cubesWidth = (int) Math.ceil(d.value().getValue() / cubeGroup.getNumCubesPerColumn() * cubeGroup.getTotalCubeSize());
         return Math.max(widestLabel, cubesWidth);
     }
+
+
+    public int getActualVerticalSize() {
+        return getActualLabelHeight() + getActualCubesHeight();
+    }
+
+    int getActualCubesHeight() {
+        return (int) Math.min(Math.round(d.value().getValue() / cubeGroup.getUnitsPerCube()), cubeGroup.getNumCubesPerColumn()) * cubeGroup.getTotalCubeSize();
+    }
+
+    public int getActualLabelHeight() {
+        return valueLabel.getActualHeight() + frameworkLabel.getActualHeight();
+    }
+
 
     @Override
     public void draw(Subcanvas dataArea, Theme theme) {
@@ -84,25 +94,25 @@ public class Cubes implements ElasticElement {
         // If this framework isn't found, it will just be the text colour, which is fine
         dataArea.setPaint(theme.chartElements().get(d.framework()));
 
-        int cubeSize = totalCubeSize - CUBE_PADDING;
+        int cubeSize = cubeGroup.getTotalCubeSize() - CUBE_PADDING;
 
-        Subcanvas cubeArea = new Subcanvas(dataArea, dataArea.getWidth(), numCubesPerColumn * totalCubeSize, 0, 0);
+        Subcanvas cubeArea = new Subcanvas(dataArea, dataArea.getWidth(), cubeGroup.getNumCubesPerColumn() * cubeGroup.getTotalCubeSize(), 0, 0);
 
         Subcanvas labelArea = new Subcanvas(dataArea, dataArea.getWidth(), dataArea.getHeight() - cubeArea.getHeight(), 0,
                 cubeArea.getHeight());
 
-        int startingY = cubeArea.getHeight() - totalCubeSize;
+        int startingY = cubeArea.getHeight() - cubeGroup.getTotalCubeSize();
 
         // Center the cubes
-        int cx = (cubeArea.getWidth() - (getColumnCount() * totalCubeSize)) / 2;
+        int cx = (cubeArea.getWidth() - (getColumnCount() * cubeGroup.getTotalCubeSize())) / 2;
         int cy = startingY;
-        int numCubes = (int) Math.round(val / unitsPerCube);
+        int numCubes = (int) Math.round(val / cubeGroup.getUnitsPerCube());
 
         for (int i = 0; i < numCubes; i++) {
             cubeArea.fillRect(cx, cy, cubeSize, cubeSize);
-            cy -= totalCubeSize;
-            if ((i + 1) % numCubesPerColumn == 0) {
-                cx += totalCubeSize;
+            cy -= cubeGroup.getTotalCubeSize();
+            if ((i + 1) % cubeGroup.getNumCubesPerColumn() == 0) {
+                cx += cubeGroup.getTotalCubeSize();
                 cy = startingY;
             }
 
@@ -114,17 +124,13 @@ public class Cubes implements ElasticElement {
         valueLabel.draw(labelArea, labelArea.getWidth() / 2, frameworkLabel.getActualHeight());
     }
 
-    // Includes the padding
-    public void setCubeSize(int totalCubeSize) {
-        this.totalCubeSize = totalCubeSize;
-    }
-
     public int getColumnCount() {
-        return (int) Math.ceil(d.value().getValue() / (numCubesPerColumn * unitsPerCube));
+        return (int) Math.ceil(d.value().getValue() / (cubeGroup.getNumCubesPerColumn() * cubeGroup.getUnitsPerCube()));
     }
 
     public void decrementFonts() {
         frameworkLabel.setTargetHeight((int) (frameworkLabel.getTargetHeight() * DECREMENT_INCREMENT));
         valueLabel.setTargetHeight((int) (valueLabel.getTargetHeight() * DECREMENT_INCREMENT));
     }
+
 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubeChartTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubeChartTest.java
@@ -2,8 +2,6 @@ package io.quarkus.infra.performance.graphics.charts;
 
 import io.quarkus.infra.performance.graphics.PlotDefinition;
 import io.quarkus.infra.performance.graphics.model.BenchmarkData;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class CubeChartTest extends ChartTest {
 
@@ -11,34 +9,4 @@ public class CubeChartTest extends ChartTest {
     protected CubeChart createChart(PlotDefinition plotDefinition, BenchmarkData data) {
         return new CubeChart(plotDefinition, data.results().getDatasets(plotDefinition.fun()), data);
     }
-
-    @Override
-    @Disabled
-    @Test
-    public void testCanDrawSmallGroupInMinimumDimensions() {
-
-    }
-
-    @Override
-    @Disabled
-    @Test
-    public void testCanDrawLargeGroupInMinimumDimensions() {
-
-    }
-
-    @Override
-    @Disabled
-    @Test
-    public void testCanDrawLargeGroupInPreferredDimensions() {
-
-    }
-
-    @Override
-    @Disabled
-    @Test
-    public void testCanDrawEmptyGroupInPreferredDimensions() {
-
-    }
-
-
 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubesTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubesTest.java
@@ -15,7 +15,7 @@ class CubesTest {
         Memory m = new Memory(315);
         Datapoint d = new Datapoint(Framework.SPRING3_JVM, m);
 
-        Cubes chart = new Cubes(d);
+        Cubes chart = new Cubes(d, new CubeGroup());
 
         int preferredWidth = chart.getPreferredHorizontalSize();
         int preferredHeight = chart.getPreferredVerticalSize();
@@ -38,7 +38,7 @@ class CubesTest {
         Memory m = new Memory(70);
         Datapoint d = new Datapoint(Framework.QUARKUS3_VIRTUAL, m);
 
-        Cubes chart = new Cubes(d);
+        Cubes chart = new Cubes(d, new CubeGroup());
 
         int preferredWidth = chart.getPreferredHorizontalSize();
         int preferredHeight = chart.getPreferredVerticalSize();


### PR DESCRIPTION
The logic for deciding how big cubes and labels should be was fairly tortured. I think I've made it clearer, and also more correct 

1. Do all the label texts fit in horizontally? If not, shrink it 
1. Shrink cubes until all the cubes fits in horizontally
1. Do things fit in vertically?  If not, we have a choice of shrinking cubes, or shrinking text. That’s a decision we make based on how much vertical space each occupies. 

One semi-unintended consequence of this is that the default size of the 'all' memory chart is a lot wider. I've stared at it and I think the new calculation is correct, it's just ... bigger. In practice, that means the fine print is smaller when it's shrunk down. I'm not delighted by that, but putting a cap on the size is hard without messing up the aspect ratio. When #176 is done the geometry will change anyway, so I'm going to leave it for now. 
