### PR TITLE
Expand hex code to six digits to fix divider colour

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/Theme.java
@@ -15,7 +15,7 @@ public record Theme(String name, Color background, Color text, Color divider, Co
     public static final Color SPRING_GREEN = decode("#6ab443");
     public static final Color SPRING_LIGHT_GREEN = decode("#c3e1b4");
 
-    public static final Color LIGHT_DIVIDER = decode("#aaa");
+    public static final Color LIGHT_DIVIDER = decode("#AAAAAA");
     public static final Color DARK_DIVIDER = decode("#555555");
 
     public static final Color BARELY_GREY = decode("#F9FBFB");


### PR DESCRIPTION
I tried to align to main Quarkus grey, and ended up with blue. Turns out that awt can't handle short-form hex codes.

Before: 
<img width="257" height="58" alt="image" src="https://github.com/user-attachments/assets/3b9b6cf0-b3e7-40de-bbf8-3eb9549beb05" />
