### PR TITLE
Fix edge case when value is lower than cubes in a column

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Cubes.java
@@ -51,7 +51,7 @@ public class Cubes implements ElasticElement {
 
     @Override
     public int getMinimumVerticalSize() {
-        return (int) Math.min(cubeGroup.getNumCubesPerColumn(), d.value().getValue()/cubeGroup.getUnitsPerCube()) * MINIMUM_CUBE_SIZE + valueLabel.getTargetHeight()
+        return (int) Math.min(cubeGroup.getNumCubesPerColumn(), d.value().getValue() / cubeGroup.getUnitsPerCube()) * MINIMUM_CUBE_SIZE + valueLabel.getTargetHeight()
                 + frameworkLabel.getTargetHeight();
     }
 
@@ -96,7 +96,7 @@ public class Cubes implements ElasticElement {
 
         int cubeSize = cubeGroup.getTotalCubeSize() - CUBE_PADDING;
 
-        Subcanvas cubeArea = new Subcanvas(dataArea, dataArea.getWidth(), cubeGroup.getNumCubesPerColumn() * cubeGroup.getTotalCubeSize(), 0, 0);
+        Subcanvas cubeArea = new Subcanvas(dataArea, dataArea.getWidth(), Math.min(cubeGroup.getNumCubesPerColumn(), (int) (val / cubeGroup.getUnitsPerCube())) * cubeGroup.getTotalCubeSize(), 0, 0);
 
         Subcanvas labelArea = new Subcanvas(dataArea, dataArea.getWidth(), dataArea.getHeight() - cubeArea.getHeight(), 0,
                 cubeArea.getHeight());

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
@@ -2,6 +2,7 @@ package io.quarkus.infra.performance.graphics.charts;
 
 import java.util.Random;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.quarkus.infra.performance.graphics.PlotDefinition;
 import io.quarkus.infra.performance.graphics.SingleSeriesPlotDefinition;
@@ -137,6 +138,23 @@ public abstract class ChartTest extends ElasticElementTest {
     @Test
     public void testCanDrawSoloGroupInPreferredDimensions() {
         BenchmarkData data = mockBenchmarkData(1);
+        System.out.println("Data " + data);
+        PlotDefinition plotDefinition = createPlotDefinition();
+
+        Chart chart = createChart(plotDefinition, data);
+
+        int width = chart.getPreferredHorizontalSize();
+        int height = chart.getPreferredVerticalSize();
+
+        SVGGraphics2D svgGenerator = getSvgGraphics2D(width, height);
+        Theme theme = Theme.LIGHT;
+        chart.draw(new Subcanvas(svgGenerator), theme);
+    }
+
+    // This sometimes fails for the cube chart, if the value is less than the column height
+    @Test
+    public void testCanDrawSoloGroupWithLowValueInPreferredDimensions() {
+        BenchmarkData data = mockBenchmarkData(1, () -> 2.0);
         PlotDefinition plotDefinition = createPlotDefinition();
 
         Chart chart = createChart(plotDefinition, data);
@@ -174,13 +192,18 @@ public abstract class ChartTest extends ElasticElementTest {
         return mockBenchmarkData(4);
     }
 
+
     private static BenchmarkData mockBenchmarkData(int count) {
+        return mockBenchmarkData(count, () -> (double) new Random().nextInt(400));
+    }
+
+    private static BenchmarkData mockBenchmarkData(int count, Supplier<Double> value) {
         BenchmarkData data = mock(BenchmarkData.class);
         Results results = new Results();
         when(data.results()).thenReturn(results);
         when(data.group()).thenReturn(Group.ALL);
         for (int i = 0; i < count; i++) {
-            addDatapoint(data, Framework.values()[i], (double) new Random().nextInt(400));
+            addDatapoint(data, Framework.values()[i], value.get());
         }
         addConfig(data);
         return data;


### PR DESCRIPTION
Sometimes the CI runs fail with a test failure. It's an edge case sometimes exposed by the random data, so I've fixed the edge case and added a permanent test. I've checked with stubbed values and the charts look ok in the low-value case now:

<img width="1076" height="300" alt="image" src="https://github.com/user-attachments/assets/359fee1e-32a6-4752-bde7-22d1d27685e5" />
