### PR TITLE
Fix font fallbacks

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/SvgAdjuster.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/SvgAdjuster.java
@@ -8,24 +8,28 @@ import org.jsoup.select.Elements;
 
 public class SvgAdjuster {
 
-    public static final String GRAPHICS_ELEMENT = "g";
     public static final String STYLE = "style";
-    public static final String FONT_FAMILY_DECLARATION = "font-family:\\s*'" + Theme.FONT.getName() + "'";
 
     public static String adjustSvg(String svg) {
         Document svgDoc = Jsoup.parse(svg, "", Parser.xmlParser());
 
-        Elements gElements = svgDoc.select(GRAPHICS_ELEMENT);
+        // Some of the font information (for bold) is on the g elements, and some (for light and italic) is on the text elements
+        addFallbackFonts(svgDoc, "text");
+        addFallbackFonts(svgDoc, "g");
 
+        return svgDoc.outerHtml();
+    }
+
+    private static void addFallbackFonts(Document svgDoc, String selector) {
+        Elements elements = svgDoc.select(selector);
         for (String name : Theme.FONT.getNames()) {
             String fontFamilyDeclaration = "font-family:\\s*'" + name + "'";
             String fallbackString = "font-family: '" + name + "', " + Theme.FONT.getFamilyDeclaration();
-            for (Element g : gElements) {
+            for (Element g : elements) {
                 String style = g.attr(STYLE);
                 style = style.replaceAll(fontFamilyDeclaration, fallbackString);
                 g.attr(STYLE, style);
             }
         }
-        return svgDoc.outerHtml();
     }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/fonts/EmbeddableFont.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/fonts/EmbeddableFont.java
@@ -48,7 +48,7 @@ public class EmbeddableFont {
         css = dfonts.stream().map(d -> generateFontFaceCSS(d)).collect(Collectors.joining(" "));
         fonts = dfonts.stream().collect(Collectors.toMap(d -> d.style, d -> d.font()));
 
-        familyDeclaration = "'" + fontName + "', " + fallbacks.stream().map(s -> "'" + s + "'").collect(Collectors.joining(", ")).replaceAll("'sans-serif'", "sans-serif");
+        familyDeclaration = "'" + fontName + " Light', '" + fontName + "', " + fallbacks.stream().map(s -> "'" + s + "'").collect(Collectors.joining(", ")).replaceAll("'sans-serif'", "sans-serif");
 
     }
 
@@ -129,15 +129,18 @@ public class EmbeddableFont {
         // Base64 encode the font bytes
         // It would be nice to subset the characters and only include what's needed, to save file sizes
         String base64Font = Base64.getEncoder().encodeToString(downloadedFont.raw());
+        String fontName = downloadedFont.font().getFontName();
         return """
                   @font-face {
                     font-family: '%s';
                     src:
-                      url('data:font/ttf;base64,%s') format('truetype');
-                   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                      url('data:font/ttf;base64,%s') format('truetype'),
+                      local(%s),
+                      local(%s);
+                    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
                     font-style: normal;
                   }
-                """.formatted(downloadedFont.font().getFontName(), base64Font);
+                """.formatted(fontName, base64Font, fontName, fontName.replaceAll(" ", ""));
     }
 
     public String getFamilyDeclaration() {


### PR DESCRIPTION
#284 made it a bit more complicated for font fallbacks to work. That means that if you view an image from a remote server, without surrounding html, some fonts are serif fonts. (You can see it by clicking on one of the preview images or images on the front page so it comes up in its own window). 

To fix the problem, I've:
- Applied the post-processing addition of backup fonts to both `<g>` and `<text>` elements (one seems to govern the bold, and one seems to govern the plain, I think because of what batik thinks the global font is, maybe?)
- Re-added local options in the `@font-face` declaration, but we prefer the attached base64 one since that's the one we pulled metrics from
- Added the Light variation explicitly to the preferred font list