### PR TITLE
Align methods of font creation to fix Linux-only spacing issue

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
@@ -121,7 +121,7 @@ public class Label {
     public Label setTargetHeight(int height) {
         this.targetHeight = height;
         int size = strings.length > 1 ? Sizer.calculateFontSize((int) (targetHeight / (strings.length * lineSpacing))):Sizer.calculateFontSize(targetHeight);
-        baseFont = new Font(Theme.FONT.getName(), Font.PLAIN, size);
+        baseFont = Theme.FONT.getFont(PLAIN, size);
         initialiseFonts();
         return this;
     }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/fonts/EmbeddableFont.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/fonts/EmbeddableFont.java
@@ -83,7 +83,11 @@ public class EmbeddableFont {
         return fonts.values().stream().map(Font::getName).collect(Collectors.toList()).toArray(new String[0]);
     }
 
-
+    /**
+     * Gets a font instance with the specified style and size. This should be used instead of new Font(), partly for better control of styles,
+     * but also because on Linux, there's a metrics difference between fonts created using new Font() and fonts created with deriveFont().
+     * That can cause wonky spacing on CI-generated images.
+     */
     public Font getFont(FontStyle style, int size) {
         // If the style doesn't exist, fall back to the first font we find
         return fonts.get(style).deriveFont((float) size);


### PR DESCRIPTION
As well as being a time-sink to implement, #284 caused a few regressions (the positioning of the GitHub logo, the fonts when the svgs are viewed standalone from a remote server, and font spacing on the cube charts). The font spacing one was a tricky one because images I generate locally didn't show the problem, but the CI-generated images did. Fonts end up being quite environment-sensitive because they're so close to the operating system, I guess.

I don't totally understand the cause, but for the non-variable, fonts created with `new Font()` have different reported dimensions that ones created with `deriveFont()`, and the dimensions are too small, so text ends up squashed together. The easy fix is to just use `deriveFont()` everywhere, so I've done that. 

This is the 'before':

<img width="297" height="146" alt="image" src="https://github.com/user-attachments/assets/e71a7cc9-88b9-419c-9461-d0469a318e60" />
