### PR TITLE
Trigger when the content we push changes

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,11 +2,10 @@
 name: Build and deploy to GitHub Pages
 
 on:
-  workflow_run:
-    workflows: [ "Generate graphics" ]
-    types:
-      - completed
+  push:
     branches: ["main"]
+    paths:
+      - 'images/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This afternoon the actions had some problems, and failed creating or merging images PRs. It *could* be a size thing, or it might have just been that GitHub was tired. 

But looking at the non-merged images PRs made me realise the thing we care about when triggering a website refresh isn't a workflow ending, it's images changing. So I've updated the trigger. 