### PR TITLE
Omit times in timestamp

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/FinePrint.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/FinePrint.java
@@ -28,7 +28,7 @@ import static io.quarkus.infra.performance.graphics.model.Category.QUARKUS;
 import static io.quarkus.infra.performance.graphics.model.Category.SPRING;
 
 public class FinePrint implements ElasticElement {
-    static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final String SOURCE_CODE_LABEL = "Source:";
 
     private static final int MAXIMUM_FONT_SIZE = 30;


### PR DESCRIPTION
What do you think of this, @edeandrea? I'm on the fence a bit. 

I like the idea of streamlining the information we show, and I don't think many people will care what time of day we ran a benchmark. On the other hand, the extra precision isn't hurting anything. 

I guess removing it might give us space to spell out a month, which might be friendlier to read? 