### PR TITLE
Tidy: do not initialise random repeatedly in unit tests

### DIFF
--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.when;
 
 public abstract class ChartTest extends ElasticElementTest {
 
+    protected static final Random RANDOM = new Random();
+
     @Test
     public void testBoundsOnDimensionsForSmallGroup() {
         BenchmarkData data = mockBenchmarkData(2);
@@ -194,7 +196,7 @@ public abstract class ChartTest extends ElasticElementTest {
 
 
     private static BenchmarkData mockBenchmarkData(int count) {
-        return mockBenchmarkData(count, () -> (double) new Random().nextInt(400));
+        return mockBenchmarkData(count, () -> (double) RANDOM.nextInt(400));
     }
 
     private static BenchmarkData mockBenchmarkData(int count, Supplier<Double> value) {

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubesTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/CubesTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import java.util.Random;
-
 import io.quarkus.infra.performance.graphics.model.Framework;
 import io.quarkus.infra.performance.graphics.model.units.Memory;
 import org.junit.jupiter.api.Test;
@@ -54,10 +52,6 @@ class CubesTest {
 
         assertTrue(preferredHeight <= maximumHeight, preferredHeight + " > " + maximumHeight);
         assertTrue(preferredHeight >= minimumHeight, preferredHeight + " > " + minimumHeight);
-    }
-
-    private static Memory getRandomMemory() {
-        return new Memory(new Random().nextDouble() * 1000);
     }
 
 }


### PR DESCRIPTION
Today's Quarkus Insights reminded me that I had lazily used `new Random()` in a method, with an intention to go back and tidy it up. 