### PR TITLE
Add PngExporter for SVG to PNG conversion

### DIFF
--- a/graphics-generator/pom.xml
+++ b/graphics-generator/pom.xml
@@ -61,12 +61,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ExportException.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ExportException.java
@@ -1,0 +1,7 @@
+package io.quarkus.infra.performance.graphics;
+
+public class ExportException extends RuntimeException {
+  public ExportException(Exception t) {
+    super(t);
+  }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
@@ -9,6 +9,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
+
 import jakarta.inject.Inject;
 
 import io.quarkus.infra.performance.graphics.charts.BarChart;
@@ -20,6 +21,7 @@ import io.quarkus.infra.performance.graphics.model.CompositePlotDefinition;
 import io.quarkus.infra.performance.graphics.model.Config;
 import io.quarkus.infra.performance.graphics.model.Group;
 import io.quarkus.infra.performance.graphics.model.Repo;
+
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
@@ -116,10 +118,10 @@ public class GraphicsCommand implements Runnable {
             BenchmarkData data = allData.subgroup(group);
             if (data.results() != null && data.results().size() > 0) {
                 try {
-                    var lightFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data, Theme.LIGHT)).toFile();
+                    var lightFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data, Theme.LIGHT));
                     generator.generate(chartConstructor, data, plotDefinition, lightFile, Theme.LIGHT);
 
-                    var darkFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data, Theme.DARK)).toFile();
+                    var darkFile = qualifiedOutputDir.resolve(deriveOutputFilename(file, plotDefinition, data, Theme.DARK));
                     generator.generate(chartConstructor, data, plotDefinition, darkFile, Theme.DARK);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/ImageGenerator.java
@@ -1,18 +1,18 @@
 package io.quarkus.infra.performance.graphics;
 
+import static io.quarkus.infra.performance.graphics.SvgAdjuster.adjustSvg;
+
 import java.awt.Dimension;
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.function.BiFunction;
-import jakarta.enterprise.context.ApplicationScoped;
 
-import io.quarkus.infra.performance.graphics.charts.Chart;
-import io.quarkus.infra.performance.graphics.charts.InlinedSVG;
-import io.quarkus.infra.performance.graphics.charts.Subcanvas;
-import io.quarkus.infra.performance.graphics.model.BenchmarkData;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.svggen.SVGGraphics2D;
@@ -21,21 +21,26 @@ import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import static io.quarkus.infra.performance.graphics.SvgAdjuster.adjustSvg;
+import io.quarkus.infra.performance.graphics.charts.Chart;
+import io.quarkus.infra.performance.graphics.charts.InlinedSVG;
+import io.quarkus.infra.performance.graphics.charts.Subcanvas;
+import io.quarkus.infra.performance.graphics.model.BenchmarkData;
 
 @ApplicationScoped
 public class ImageGenerator {
     private static final String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;
 
+    @Inject
+    PngExporter pngExporter;
+
     public void generate(BiFunction<PlotDefinition, BenchmarkData, Chart> chartConstructor, BenchmarkData data,
-                         PlotDefinition plotDefinition, File outFile, Theme theme)
+                         PlotDefinition plotDefinition, Path outFile, Theme theme)
             throws IOException {
         if (data != null && data.results() != null) {
             DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
             Document doc = impl.createDocument(svgNS, "svg", null);
 
-            Chart chart = chartConstructor.apply(plotDefinition,
-                    data);
+            Chart chart = chartConstructor.apply(plotDefinition, data);
 
             SVGGraphics2D svgGenerator = new SVGGraphics2D(doc);
             svgGenerator.setSVGCanvasSize(
@@ -47,20 +52,18 @@ public class ImageGenerator {
             initialiseFonts(doc, root);
             inlineGraphics(doc, root, chart.getInlinedSVGs(), theme);
 
-            outFile.getParentFile().mkdirs();
+            Files.createDirectories(outFile.getParent());
 
-            StringWriter buffer = new StringWriter();
-            svgGenerator.stream(root, buffer, true, false);
-            String svg = buffer.toString();
-
-            String adjusted = adjustSvg(svg);
-
-            try (FileWriter writer = new FileWriter(outFile)) {
-                writer.write(adjusted);
+            try (var buffer = new StringWriter()) {
+              svgGenerator.stream(root, buffer, true, false);
+              var svg = buffer.toString();
+              var adjusted = adjustSvg(svg);
+              Files.writeString(outFile, adjusted);
             }
 
+            this.pngExporter.exportAsPng(outFile);
         } else {
-            System.out.printf("\uD83D\uDDD1️ Not generating image for %s (no data)\n", outFile.getAbsolutePath());
+            System.out.printf("\uD83D\uDDD1️ Not generating image for %s (no data)\n", outFile.toAbsolutePath());
 
         }
     }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/PngExporter.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/PngExporter.java
@@ -1,0 +1,50 @@
+package io.quarkus.infra.performance.graphics;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.batik.transcoder.TranscoderException;
+import org.apache.batik.transcoder.TranscoderInput;
+import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.image.PNGTranscoder;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class PngExporter {
+  // Batik 1.19's CSS parser does not support CSS3 @font-face src descriptors with
+  // url()/format()/local() function values. Since fonts are registered with Java's
+  // GraphicsEnvironment, Batik resolves them by name without needing @font-face rules.
+  private static final Pattern FONT_FACE_PATTERN = Pattern.compile(
+      "@font-face\\s*\\{[^}]*\\}", Pattern.DOTALL);
+
+  private final PNGTranscoder pngTranscoder = new PNGTranscoder();
+  
+  public void exportAsPng(Path svgFile) {
+    if ((svgFile != null) && Files.isRegularFile(svgFile)) {
+      Log.debugf("Exporting %s as PNG", svgFile);
+
+      var pngFile = svgFile.resolveSibling(svgFile.getFileName().toString().replace(".svg", ".png"));
+
+      try (var pngOutputStream = Files.newOutputStream(pngFile)) {
+        var svgContent = Files.readString(svgFile);
+        var sanitized = FONT_FACE_PATTERN.matcher(svgContent).replaceAll("");
+        var transcoderInput = new TranscoderInput(new StringReader(sanitized));
+        transcoderInput.setURI(svgFile.toUri().toString());
+
+        var transcoderOutput = new TranscoderOutput(pngOutputStream);
+        transcoderOutput.setURI(pngFile.toUri().toString());
+
+        this.pngTranscoder.transcode(transcoderInput, transcoderOutput);
+      }
+      catch (TranscoderException | IOException e) {
+        throw new ExportException(e);
+      }
+    }
+  }
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/InlinedSVGLink.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/InlinedSVGLink.java
@@ -37,7 +37,8 @@ public class InlinedSVGLink extends InlinedSVG {
 
         textElement.setAttributeNS(null, "x", String.valueOf(x));
         textElement.setAttributeNS(null, "y", String.valueOf(y));
-        textElement.setAttributeNS(null, "fill", "rgba(0, 0, 0, 0)"); // make the text invisible, but still accessible to text readers
+        textElement.setAttributeNS(null, "fill", "#000000"); // make the text invisible, but still accessible to text readers
+        textElement.setAttributeNS(null, "fill-opacity", "0");
         textElement.setAttributeNS(null, "stroke", "none"); // without this, the colours and other styling has no effect
         textElement.setAttributeNS("http://www.w3.org/XML/1998/namespace", "xml:space", "preserve"); // otherwise spaces are collapsed and the hot area is too small
 

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/GraphicsCommandTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/GraphicsCommandTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.infra.performance.graphics;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -10,17 +13,15 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 
-import io.quarkus.test.junit.main.Launch;
-import io.quarkus.test.junit.main.LaunchResult;
-import io.quarkus.test.junit.main.QuarkusMainLauncher;
-import io.quarkus.test.junit.main.QuarkusMainTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 @QuarkusMainTest
 public class GraphicsCommandTest {
@@ -114,19 +115,21 @@ public class GraphicsCommandTest {
 
         File image = new File("target/test-output/filename/data-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/data-tuned-throughput-for-all-light.png").exists());
 
         // Check groups
         image = new File("target/test-output/filename/data-tuned-throughput-for-quarkus-dark.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/data-tuned-throughput-for-quarkus-dark.png").exists());
 
         image = new File("target/test-output/filename/data-tuned-throughput-for-main-comparison-light.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/data-tuned-throughput-for-main-comparison-light.png").exists());
 
         // Check composite
-
         image = new File("target/test-output/filename/data-tuned-composite-for-main-comparison-light.svg");
         assertTrue(image.exists());
-
+        assertTrue(new File("target/test-output/filename/data-tuned-composite-for-main-comparison-light.png").exists());
     }
 
     @Test
@@ -137,6 +140,7 @@ public class GraphicsCommandTest {
 
         File image = new File("target/test-output/filename/tempfile-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/tempfile-tuned-throughput-for-all-light.png").exists());
     }
 
     @Test
@@ -147,6 +151,7 @@ public class GraphicsCommandTest {
 
         File image = new File("target/test-output/filename/data-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/data-tuned-throughput-for-all-light.png").exists());
     }
 
     @Test
@@ -157,10 +162,12 @@ public class GraphicsCommandTest {
 
         File image = new File("target/test-output/filename/data-tuned-throughput-for-all-light.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/data-tuned-throughput-for-all-light.png").exists());
 
         // Check parentheseses are stripped
         image = new File("target/test-output/filename/data-tuned-memory-rss-for-all-dark.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/data-tuned-memory-rss-for-all-dark.png").exists());
     }
 
     @Test
@@ -173,13 +180,19 @@ public class GraphicsCommandTest {
         File dir = new File("target/test-output/directory/");
         File image1 = new File(dir, "data-tuned-throughput-for-all-light.svg");
         assertTrue(image1.exists());
+        assertTrue(new File(dir, "data-tuned-throughput-for-all-light.png").exists());
+
         File image2 = new File(dir, "eight-framework-tuned-throughput-for-all-light.svg");
         assertTrue(image2.exists());
+        assertTrue(new File(dir, "eight-framework-tuned-throughput-for-all-light.png").exists());
+
 
         File nestedDir = new File("target/test-output/directory/nested/more-nested");
         assertTrue(nestedDir.exists());
+
         File image3 = new File(nestedDir, "data3-ootb-throughput-for-all-light.svg");
         assertTrue(image3.exists());
+        assertTrue(new File(nestedDir, "data3-ootb-throughput-for-all-light.png").exists());
     }
 
     @Test
@@ -190,6 +203,7 @@ public class GraphicsCommandTest {
 
         File image = new File("target/test-output/filename/data-tuned-throughput-for-all-dark.svg");
         assertTrue(image.exists());
+        assertTrue(new File("target/test-output/filename/data-tuned-throughput-for-all-dark.png").exists());
     }
 
     @Test
@@ -201,14 +215,17 @@ public class GraphicsCommandTest {
         // Verify that images are generated successfully even with unknown frameworks
         File image = new File("target/test-output/unknown-framework/data-unknown-framework-throughput-for-all-light.svg");
         assertTrue(image.exists(), "Image should be generated for JSON with unknown framework");
+        assertTrue(new File("target/test-output/unknown-framework/data-unknown-framework-throughput-for-all-light.png").exists(),"Image should be generated for JSON with unknown framework");
 
         // Verify dark mode image is also generated
         File darkImage = new File("target/test-output/unknown-framework/data-unknown-framework-throughput-for-all-dark.svg");
         assertTrue(darkImage.exists(), "Dark mode image should be generated for JSON with unknown framework");
+        assertTrue(new File("target/test-output/unknown-framework/data-unknown-framework-throughput-for-all-dark.png").exists(), "Dark mode image should be generated for JSON with unknown framework");
 
         // Verify composite image is also generated
         File compositeImage = new File("target/test-output/unknown-framework/data-unknown-framework-composite-for-all-light.svg");
         assertTrue(compositeImage.exists(), "Composite image should be generated for JSON with unknown framework");
+        assertTrue(new File("target/test-output/unknown-framework/data-unknown-framework-composite-for-all-light.png").exists(), "Composite image should be generated for JSON with unknown framework");
     }
 
 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/ImageGeneratorTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.infra.performance.graphics;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -7,7 +11,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Function;
+
 import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.quarkus.infra.performance.graphics.charts.BarChart;
 import io.quarkus.infra.performance.graphics.model.BenchmarkData;
@@ -24,12 +32,6 @@ import io.quarkus.infra.performance.graphics.model.UnknownFramework;
 import io.quarkus.infra.performance.graphics.model.units.DimensionalNumber;
 import io.quarkus.infra.performance.graphics.model.units.TransactionsPerSecond;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @QuarkusTest
 class ImageGeneratorTest {
@@ -63,7 +65,7 @@ class ImageGeneratorTest {
             addConfig(data);
             Function<Result, ? extends DimensionalNumber> fun = framework -> framework.load().avThroughput();
             PlotDefinition plotDefinition = new SingleSeriesPlotDefinition("test plot", "some subtitle", fun);
-            imageGenerator.generate(BarChart::new, data, plotDefinition, new File("target/images/test1.svg"),
+            imageGenerator.generate(BarChart::new, data, plotDefinition, Path.of("target/images/test1.svg"),
                     Theme.LIGHT);
             image = new File("target/images/test1.svg");
         } else {


### PR DESCRIPTION
I was running into errors during the conversion when I set `fill: rgba(0,0,0,0)`. I tried `fill: transparent` but it didn't like that either.

Claude mentioned that `fill: #000000; fill-opacity: 0` gave the same thing, and now the transcoder seems to work.

Fixes #94