### PR TITLE
Fix preview workflow permissions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,6 +12,11 @@ concurrency:
   group: git-operations
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
 jobs:
   preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The preview workflow was failing with `Permission to quarkusio/benchmarks.git denied to github-actions[bot]` (403) when trying to push to the `pr-images` branch
- Root cause: the workflow had no `permissions` block, so `GITHUB_TOKEN` defaulted to read-only
- Adds `contents: write` (for git push), `pull-requests: write` (for PR comments), and `actions: read` (for artifact downloads), matching the permissions already set in `graphics.yml`

Fixes https://github.com/quarkusio/benchmarks/actions/runs/24746176247/job/72398290059

## Test plan
- [ ] Open a PR that changes graphics-generator code to trigger the Generate graphics workflow
- [ ] Verify the preview workflow succeeds and posts an image preview comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)