### PR TITLE
Mirror boot times in composite chart

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/GraphicsCommand.java
@@ -29,9 +29,9 @@ import picocli.CommandLine.Parameters;
 public class GraphicsCommand implements Runnable {
     private static final PlotDefinition THROUGHPUT = new SingleSeriesPlotDefinition("Throughput", "(Higher is better)", framework -> framework.load().avThroughput());
     private static final PlotDefinition RSS = new SingleSeriesPlotDefinition("Memory (RSS after first request)", "memory-rss", "(Smaller is better)", framework -> framework.rss().avFirstRequestRss());
-    private static final PlotDefinition TIME_TO_FIRST_REQUEST = new SingleSeriesPlotDefinition("Boot + First Response Time", "(Lower is better)", framework -> framework.startup().avStartTime());
+    private static final PlotDefinition TIME_TO_FIRST_REQUEST = new SingleSeriesPlotDefinition("Boot + First Response Time", "(Shorter is better)", framework -> framework.startup().avStartTime());
     private static final PlotDefinition BUILD_TIME = new SingleSeriesPlotDefinition("Build Duration", "(Shorter is better)", framework -> framework.build().avBuildTime());
-    private static final PlotDefinition FRONT_PAGE = new CompositePlotDefinition("composite", List.of(THROUGHPUT, TIME_TO_FIRST_REQUEST, RSS));
+    private static final PlotDefinition FRONT_PAGE = new CompositePlotDefinition("composite", List.of(TIME_TO_FIRST_REQUEST, THROUGHPUT, RSS));
 
     @Parameters(paramLabel = "<filename>", defaultValue = "latest.json", description = "A filename of json-formatted data, or a directory. For directories, .json files in the directory will be processed recursively.")
     Path filename;

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
@@ -1,5 +1,7 @@
 package io.quarkus.infra.performance.graphics.charts;
 
+import java.util.Optional;
+
 import io.quarkus.infra.performance.graphics.Theme;
 import io.quarkus.infra.performance.graphics.charts.fonts.Alignment;
 import io.quarkus.infra.performance.graphics.charts.fonts.FontStyle;
@@ -26,19 +28,35 @@ public class Bar extends ScaledElement {
     private final Datapoint d;
 
     private final String frameworkLabelText;
+    private final boolean showFrameworkLabels;
+    private boolean isInverted;
 
-    public Bar(Datapoint d, LabelGroup frameworkLabelGroup, LabelGroup valueLabelGroup, ScaleGroup scaleGroup) {
+    public Bar(Datapoint d, LabelGroup frameworkLabelGroup, LabelGroup valueLabelGroup, ScaleGroup scaleGroup, Optional<EmbedOptions> embedOptions) {
         super(scaleGroup);
+        isInverted = embedOptions.isPresent() ? embedOptions.get().isInverted():false;
+        showFrameworkLabels = embedOptions.isPresent() ? embedOptions.get().showFrameworkLabels():true;
         this.d = d;
         double val = d.value().getValue();
-        frameworkLabelText = d.framework().getExpandedName();
+
+        frameworkLabelText = showFrameworkLabels ? d.framework().getExpandedName():"";
         frameworkLabel = new Label(frameworkLabelText, frameworkLabelGroup)
-                .setHorizontalAlignment(Alignment.RIGHT)
                 .setVerticalAlignment(VAlignment.MIDDLE)
                 .setStyles(new FontStyle[]{BOLD, PLAIN})
                 .setTargetHeight(BAR_THICKNESS);
+
+        if (embedOptions.isPresent()) {
+            frameworkLabel.setHorizontalAlignment(Alignment.CENTER);
+        } else {
+            frameworkLabel.setHorizontalAlignment(Alignment.RIGHT);
+        }
+
         String valueLabelText = String.format("%d %s", Math.round(val), d.value().getUnits());
         valueLabel = new Label(valueLabelText, valueLabelGroup).setStyle(BOLD).setTargetHeight(VALUE_LABEL_HEIGHT);
+
+        if (isInverted) {
+            valueLabel.setHorizontalAlignment(Alignment.RIGHT);
+        }
+
 
         // This will probably be overridden, but set a value
         offset = Sizer.calculateWidth(frameworkLabelText, LEFT_LABEL_SIZE) + LABEL_PADDING;
@@ -80,21 +98,33 @@ public class Bar extends ScaledElement {
         int labelY = barArea.getHeight() / 2;
 
         barArea.setPaint(theme.text());
-        int leftLabelWidth = offset - LABEL_PADDING;
+        final int frameworkTextWidth = offset - LABEL_PADDING; // Offset includes the label padding,
+        int leftLabelX = switch (frameworkLabel.getHorizontalAligment()) {
+            case Alignment.CENTER ->
+                    (frameworkTextWidth) / 2; // We want half the text width and half of a label paddings
+            case Alignment.RIGHT -> frameworkTextWidth;
+            case Alignment.LEFT -> 0;
+        };
 
-        Subcanvas frameworkSubcanvas = new Subcanvas(barArea, leftLabelWidth, frameworkLabel.getTargetHeight(), 0, 0);
-        frameworkLabel.draw(frameworkSubcanvas, leftLabelWidth, labelY);
-        Subcanvas barSubcanvas = new Subcanvas(barArea, barArea.getWidth() - offset, frameworkLabel.getTargetHeight(), offset, 0);
+        Subcanvas frameworkSubcanvas = new Subcanvas(barArea, frameworkTextWidth, frameworkLabel.getTargetHeight(), 0, 0);
+        frameworkLabel.draw(frameworkSubcanvas, leftLabelX, labelY);
+
+        int barx = isInverted ? 0:offset;
+        Subcanvas barSubcanvas = new Subcanvas(barArea, barArea.getWidth() - offset, frameworkLabel.getTargetHeight(), barx, 0);
 
         // If this framework isn't found, it will just be the text colour, which is fine
         barSubcanvas.setPaint(theme.chartElements().get(d.framework()));
         int length = (int) (val * scaleGroup.getScale());
         int y = (barArea.getHeight() - BAR_THICKNESS) / 2;
-        barSubcanvas.fillRect(0, y, length, BAR_THICKNESS);
+
+        int x = isInverted ? barSubcanvas.getWidth() - length:0;
+        int labelX = isInverted ? (barSubcanvas.getWidth() - length - LABEL_PADDING):length + LABEL_PADDING;
+
+        barSubcanvas.fillRect(x, y, length, BAR_THICKNESS);
 
         barSubcanvas.setPaint(theme.text());
 
-        valueLabel.setTargetHeight(BAR_THICKNESS * 2 / 3).draw(barSubcanvas, length + LABEL_PADDING, labelY);
+        valueLabel.setTargetHeight(BAR_THICKNESS * 2 / 3).draw(barSubcanvas, labelX, labelY);
     }
 
     public int getMaximumBarWidth(Subcanvas barArea) {

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
@@ -57,7 +57,6 @@ public class Bar extends ScaledElement {
             valueLabel.setHorizontalAlignment(Alignment.RIGHT);
         }
 
-
         // This will probably be overridden, but set a value
         offset = Sizer.calculateWidth(frameworkLabelText, LEFT_LABEL_SIZE) + LABEL_PADDING;
     }
@@ -99,7 +98,7 @@ public class Bar extends ScaledElement {
 
         barArea.setPaint(theme.text());
         final int frameworkTextWidth = offset - LABEL_PADDING; // Offset includes the label padding,
-        int leftLabelX = switch (frameworkLabel.getHorizontalAligment()) {
+        int leftLabelX = switch (frameworkLabel.getHorizontalAlignment()) {
             case Alignment.CENTER ->
                     (frameworkTextWidth) / 2; // We want half the text width and half of a label paddings
             case Alignment.RIGHT -> frameworkTextWidth;

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -26,11 +26,14 @@ public class BarChart extends SingleSeriesChart {
     private final ScaleGroup scaleGroup = new ScaleGroup();
 
     public BarChart(PlotDefinition plotDefinition, BenchmarkData bmData) {
-        this(plotDefinition, bmData, false);
+        this(plotDefinition, bmData, Optional.empty());
     }
 
-    public BarChart(PlotDefinition plotDefinition, BenchmarkData bmData, boolean isEmbedded) {
-        super(plotDefinition, bmData);
+    public BarChart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
+        super(plotDefinition, bmData, embedOptions);
+
+        boolean isInverted = embedOptions.isPresent() ? embedOptions.get().isInverted():false;
+        boolean isEmbedded = embedOptions.isPresent();
 
         if (! isEmbedded) {
             this.fineprint = Optional.of(new FinePrint(bmData));
@@ -49,19 +52,23 @@ public class BarChart extends SingleSeriesChart {
             Category newCategory = d.framework().getPartitionableCategory();
             if (shouldUsePartitions) {
                 if (newCategory != null && previousCategory != null && ! newCategory.equals(previousCategory)) {
-                    ScaleDivider e1 = new ScaleDivider(maxValue, scaleGroup);
+                    ScaleDivider e1 = new ScaleDivider(maxValue, scaleGroup, isInverted);
                     barsAndPartitions.add(e1);
                     children.add(e1);
                 }
             }
 
-            Bar e = new Bar(d, frameworkLabelGroup, valueLabelGroup, scaleGroup);
+            Bar e = new Bar(d, frameworkLabelGroup, valueLabelGroup, scaleGroup, embedOptions);
             bars.add(e);
             barsAndPartitions.add(e);
             children.add(e);
             previousCategory = newCategory;
         }
 
+    }
+
+    public BarChart(PlotDefinition pd, BenchmarkData bmData, EmbedOptions embedOptions) {
+        this(pd, bmData, Optional.of(embedOptions));
     }
 
     private int countPartitions(List<Datapoint> data) {
@@ -100,23 +107,22 @@ public class BarChart extends SingleSeriesChart {
             barHeight = canvasWithMargins.getHeight() - titleHeight - finePrintHeight;
         }
 
-        canvasWithMargins.setPaint(theme.text());
-        Subcanvas titleCanvas = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(), titleHeight,
-                0, 0);
-        title.draw(titleCanvas, theme);
-
-
-        Subcanvas barArea = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(),
-                barHeight, 0, titleCanvas.getHeight());
-
-        int leftLabelWidth = Sizer.calculateWidth(bars.stream().map(Bar::getLeftLabelText).collect(Collectors.toSet()),
-                frameworkLabelGroup.getFontSize());
+        int leftLabelWidth = getLeftLabelWidth();
 
         // Set a common offset for all bars and partitions before trying to calculate a scale
         int offset = leftLabelWidth + Bar.LABEL_PADDING;
         for (ScaledElement element : barsAndPartitions) {
             element.setOffset(offset);
         }
+
+        canvasWithMargins.setPaint(theme.text());
+        int titleOffset = embedOptions.isPresent() && ! embedOptions.get().isInverted() ? offset:0;
+        Subcanvas titleCanvas = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(), titleHeight,
+                titleOffset, 0);
+        title.draw(titleCanvas, theme);
+
+        Subcanvas barArea = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(),
+                barHeight, 0, titleCanvas.getHeight());
 
         double scale = bars.stream().mapToDouble(bar -> bar.getMaximumScale(barArea)).min().orElse(1);
 
@@ -137,7 +143,18 @@ public class BarChart extends SingleSeriesChart {
 
         }
 
+        if (embedOptions.isPresent()) {
+            barArea.setPaint(theme.divider());
+            int x = embedOptions.get().isInverted() ? barArea.getWidth() - offset:offset;
+            barArea.drawLine(x, 0, x, barArea.getHeight());
+        }
+
         drawFinePrint(canvasWithMargins, theme, finePrintHeight, barArea.getHeight() + titleCanvas.getHeight(), fineprint);
+    }
+
+    private int getLeftLabelWidth() {
+        return Sizer.calculateWidth(bars.stream().map(Bar::getLeftLabelText).collect(Collectors.toSet()),
+                frameworkLabelGroup.getFontSize());
     }
 
     @Override
@@ -149,4 +166,12 @@ public class BarChart extends SingleSeriesChart {
         }
     }
 
+    @Override
+    public int getCenteringOffset() {
+        if (embedOptions.isPresent() && embedOptions.get().showFrameworkLabels()) {
+            return - 1 * getLeftLabelWidth() / 2;
+        } else {
+            return super.getCenteringOffset();
+        }
+    }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
@@ -20,14 +20,24 @@ public abstract class Chart implements ElasticElement {
 
     final int xmargins = 20;
     final int ymargins = 20;
+    protected final Optional<EmbedOptions> embedOptions;
+    int lxmargin = xmargins;
+    int rxmargin = xmargins;
 
-    protected Chart(PlotDefinition plotDefinition, BenchmarkData bmData) {
+    protected Chart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
         this.metadata = bmData.config();
+        this.embedOptions = embedOptions;
+
         children = new HashSet<>();
 
-        this.title = new Title(plotDefinition.title(), plotDefinition.subtitle());
+        this.title = new Title(plotDefinition.title(), plotDefinition.subtitle(), embedOptions);
+
         children.add(this.title);
 
+    }
+
+    public Chart(PlotDefinition plotDefinition, BenchmarkData bmData) {
+        this(plotDefinition, bmData, Optional.empty());
     }
 
     public void draw(Subcanvas g, Theme theme) {
@@ -43,10 +53,13 @@ public abstract class Chart implements ElasticElement {
         int canvasHeight = g.getHeight();
         int canvasWidth = g.getWidth();
 
-        g.setPaint(theme.background());
-        g.fill();
+        // Don't fill background on embedded charts, because it's unnecessary, wastes xml space in the svg, and can overwrite other chart elements
+        if (embedOptions.isEmpty()) {
+            g.setPaint(theme.background());
+            g.fill();
+        }
 
-        Subcanvas canvasWithMargins = new Subcanvas(g, canvasWidth - 2 * xmargins, canvasHeight - 2 * ymargins, xmargins,
+        Subcanvas canvasWithMargins = new Subcanvas(g, canvasWidth - lxmargin - rxmargin, canvasHeight - 2 * ymargins, lxmargin,
                 ymargins);
 
         drawNoCheck(canvasWithMargins, theme);
@@ -79,7 +92,7 @@ public abstract class Chart implements ElasticElement {
 
     @Override
     public int getMaximumHorizontalSize() {
-        return children.stream().mapToInt(ElasticElement::getMaximumHorizontalSize).max().orElse(0) + 2 * xmargins;
+        return children.stream().mapToInt(ElasticElement::getMaximumHorizontalSize).max().orElse(0) + lxmargin + rxmargin;
     }
 
     @Override
@@ -89,7 +102,7 @@ public abstract class Chart implements ElasticElement {
 
     @Override
     public int getMinimumHorizontalSize() {
-        return children.stream().mapToInt(ElasticElement::getMinimumHorizontalSize).max().orElse(0) + 2 * xmargins;
+        return children.stream().mapToInt(ElasticElement::getMinimumHorizontalSize).max().orElse(0) + lxmargin + rxmargin;
     }
 
     @Override
@@ -99,10 +112,25 @@ public abstract class Chart implements ElasticElement {
 
     @Override
     public int getPreferredHorizontalSize() {
-        return children.stream().mapToInt(ElasticElement::getPreferredHorizontalSize).max().orElse(0) + 2 * xmargins;
+        return children.stream().mapToInt(ElasticElement::getPreferredHorizontalSize).max().orElse(0) + lxmargin + rxmargin;
     }
 
     protected int getPreferredVerticalSize(int width) {
         return getPreferredVerticalSize();
+    }
+
+    /**
+     * Subclasses can override if they should be aligned differently when embedded.
+     */
+    protected int getCenteringOffset() {
+        return 0;
+    }
+
+    protected void suppressLeftMargin() {
+        lxmargin = 0;
+    }
+
+    protected void suppressRightMargin() {
+        rxmargin = 0;
     }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CompositeChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CompositeChart.java
@@ -15,18 +15,14 @@ public class CompositeChart extends Chart {
 
     private final FinePrint fineprint;
     private List<Chart> charts = new ArrayList<>();
+    private boolean inversion;
 
     public CompositeChart(PlotDefinition plotDefinition, BenchmarkData bmData) {
         super(plotDefinition, bmData);
         // The layout is a bit coupled to the chart types, so although arbitrary numbers of definitions can get passed in, only three got plotted, and they look best if they're a certain set
         if (plotDefinition instanceof CompositePlotDefinition compositePlotDefinition) {
             for (PlotDefinition pd : compositePlotDefinition.pds()) {
-                Chart chart;
-                if (pd.title().contains("Memory")) {
-                    chart = new CubeChart(pd, bmData, true);
-                } else {
-                    chart = new BarChart(pd, bmData, true);
-                }
+                Chart chart = getChartForPlotDefinition(bmData, pd);
 
                 charts.add(chart);
             }
@@ -39,6 +35,11 @@ public class CompositeChart extends Chart {
                 }
             }
 
+            if (charts.size() >= 2) {
+                charts.get(0).suppressRightMargin();
+                charts.get(1).suppressLeftMargin();
+            }
+
             this.fineprint = new FinePrint(bmData);
             children.add(fineprint);
         } else {
@@ -46,6 +47,18 @@ public class CompositeChart extends Chart {
         }
         // No title on the composite plots
         children.remove(title);
+    }
+
+    protected Chart getChartForPlotDefinition(BenchmarkData bmData, PlotDefinition pd) {
+        Chart chart;
+        if (pd.title().contains("Memory")) {
+            chart = new CubeChart(pd, bmData, new EmbedOptions(false, true));
+        } else {
+            // Toggle the inversion of bar charts
+            inversion = ! inversion;
+            chart = new BarChart(pd, bmData, new EmbedOptions(inversion, ! inversion));
+        }
+        return chart;
     }
 
     @Override
@@ -117,19 +130,19 @@ public class CompositeChart extends Chart {
 
         Subcanvas topChartArea = new Subcanvas(g, g.getWidth(), topChartsHeight, 0, 0);
 
-        Subcanvas leftArea = new Subcanvas(topChartArea, topChartArea.getWidth() / 2, topChartArea.getHeight(), 0, 0);
+        Chart rightChart = charts.get(1);
+
+        int centeringOffset = leftChart.getCenteringOffset() - rightChart.getCenteringOffset();
+
+        Subcanvas leftArea = new Subcanvas(topChartArea, topChartArea.getWidth() / 2 - centeringOffset, topChartArea.getHeight(), 0, 0);
         leftChart.draw(leftArea, theme);
 
-        Subcanvas rightArea = new Subcanvas(topChartArea, topChartArea.getWidth() / 2, topChartArea.getHeight(), leftArea.getWidth(), 0);
-        Chart rightChart = charts.get(1);
+        Subcanvas rightArea = new Subcanvas(topChartArea, topChartArea.getWidth() / 2 + centeringOffset, topChartArea.getHeight(), leftArea.getWidth(), 0);
         rightChart.draw(rightArea, theme);
 
         topChartArea.setPaint(theme.divider());
-        int x = leftArea.getWidth();
-        topChartArea.drawLine(x, 0, x, topChartArea.getHeight(), DIVIDER_WIDTH);
 
-
-        Subcanvas bottomChartArea = new Subcanvas(g, g.getWidth(), bottomChartsHeight, 0, topChartArea.getHeight() + + DIVIDER_WIDTH);
+        Subcanvas bottomChartArea = new Subcanvas(g, g.getWidth(), bottomChartsHeight, 0, topChartArea.getHeight() + DIVIDER_WIDTH);
         bottomChart.draw(bottomChartArea, theme);
 
         topChartArea.setPaint(theme.divider());

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
@@ -29,14 +29,17 @@ public class CubeChart extends SingleSeriesChart {
     private final LabelGroup valueLabelGroup = new LabelGroup();
 
     public CubeChart(PlotDefinition plotDefinition, BenchmarkData bmData) {
-        this(plotDefinition, bmData, false);
-
+        this(plotDefinition, bmData, Optional.empty());
     }
 
-    public CubeChart(PlotDefinition plotDefinition, BenchmarkData bmData, boolean isEmbedded) {
-        super(plotDefinition, bmData);
+    public CubeChart(PlotDefinition plotDefinition, BenchmarkData bmData, EmbedOptions embedOptions) {
+        this(plotDefinition, bmData, Optional.of(embedOptions));
+    }
 
-        if (! isEmbedded) {
+    public CubeChart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
+        super(plotDefinition, bmData, embedOptions);
+
+        if (embedOptions.isEmpty()) {
             this.fineprint = Optional.of(new FinePrint(bmData));
             children.add(fineprint.get());
         } else {

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/EmbedOptions.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/EmbedOptions.java
@@ -1,0 +1,5 @@
+package io.quarkus.infra.performance.graphics.charts;
+
+public record EmbedOptions(boolean isInverted, boolean showFrameworkLabels) {
+   
+}

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
@@ -142,7 +142,7 @@ public class Label {
         return this;
     }
 
-    public Alignment getHorizontalAligment() {
+    public Alignment getHorizontalAlignment() {
         return alignment;
     }
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Label.java
@@ -142,6 +142,10 @@ public class Label {
         return this;
     }
 
+    public Alignment getHorizontalAligment() {
+        return alignment;
+    }
+
     /**
      * Should be one of the constants declared in #Font or their combination
      */
@@ -234,7 +238,6 @@ public class Label {
     public void setLineSpacing(int l) {
         this.lineSpacing = l;
     }
-
 
     private record DelimitedStyles(FontStyle[] styles, String delimiter) {
     }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/SingleSeriesChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/SingleSeriesChart.java
@@ -2,6 +2,7 @@ package io.quarkus.infra.performance.graphics.charts;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import io.quarkus.infra.performance.graphics.PlotDefinition;
 import io.quarkus.infra.performance.graphics.SingleSeriesPlotDefinition;
@@ -12,8 +13,8 @@ public abstract class SingleSeriesChart extends Chart {
     protected final List<Datapoint> data;
     protected final DimensionalNumber maxValue;
 
-    protected SingleSeriesChart(PlotDefinition plotDefinition, BenchmarkData bmData) {
-        super(plotDefinition, bmData);
+    protected SingleSeriesChart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
+        super(plotDefinition, bmData, embedOptions);
         if (plotDefinition instanceof SingleSeriesPlotDefinition singleSeriesPlotDefinition) {
             this.data = bmData.results().getDatasets(singleSeriesPlotDefinition.fun());
             // Find max value, or create a default DimensionalNumber with value 1.0 if no data

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Title.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Title.java
@@ -72,7 +72,7 @@ public class Title implements ElasticElement {
         titleLabel.setTargetHeight(titleHeight);
         int topMargin = titleHeight / 2;
 
-        int x = titleLabel.getHorizontalAligment().equals(Alignment.RIGHT) ? g.getWidth():0;
+        int x = titleLabel.getHorizontalAlignment().equals(Alignment.RIGHT) ? g.getWidth():0;
         titleLabel.draw(g, x, topMargin);
 
         if (hasSubtitle()) {

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Title.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Title.java
@@ -1,6 +1,9 @@
 package io.quarkus.infra.performance.graphics.charts;
 
+import java.util.Optional;
+
 import io.quarkus.infra.performance.graphics.Theme;
+import io.quarkus.infra.performance.graphics.charts.fonts.Alignment;
 import io.quarkus.infra.performance.graphics.charts.fonts.Sizer;
 import io.quarkus.infra.performance.graphics.charts.fonts.VAlignment;
 
@@ -19,15 +22,20 @@ public class Title implements ElasticElement {
     private final Label titleLabel;
     private final Label subtitleLabel;
 
-    public Title(String title) {
-        this(title, "");
+    public Title(String title, Optional<EmbedOptions> embedOptions) {
+        this(title, "", embedOptions);
     }
 
-    public Title(String title, String subtitle) {
+    public Title(String title, String subtitle, Optional<EmbedOptions> embedOptions) {
         this.title = title;
         titleLabel = new Label(title).setStyle(BOLD).setVerticalAlignment(VAlignment.TOP);
         this.subtitle = subtitle;
         subtitleLabel = new Label(subtitle).setStyle(ITALIC).setVerticalAlignment(VAlignment.TOP);
+
+        if (embedOptions.isPresent() && embedOptions.get().isInverted()) {
+            titleLabel.setHorizontalAlignment(Alignment.RIGHT);
+            subtitleLabel.setHorizontalAlignment(Alignment.RIGHT);
+        }
     }
 
     @Override
@@ -63,12 +71,14 @@ public class Title implements ElasticElement {
         int titleHeight = (RATIO * g.getHeight()) / (2 * RATIO + subtitleFactor);
         titleLabel.setTargetHeight(titleHeight);
         int topMargin = titleHeight / 2;
-        titleLabel.draw(g, 0, topMargin);
+
+        int x = titleLabel.getHorizontalAligment().equals(Alignment.RIGHT) ? g.getWidth():0;
+        titleLabel.draw(g, x, topMargin);
 
         if (hasSubtitle()) {
             int subtitleHeight = titleHeight / RATIO;
             subtitleLabel.setTargetHeight(subtitleHeight);
-            subtitleLabel.draw(g, 0, topMargin + titleHeight);
+            subtitleLabel.draw(g, x, topMargin + titleHeight);
         }
     }
 

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/scales/ScaleDivider.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/scales/ScaleDivider.java
@@ -28,6 +28,7 @@ public class ScaleDivider extends ScaledElement {
     private final double maxValue;
     private final double[] circleValues;
     private final ValueFormatter formatter;
+    private final boolean isInverted;
 
     /**
      * Creates a scale divider with the specified maximum value and a new ScaleGroup.
@@ -36,7 +37,7 @@ public class ScaleDivider extends ScaledElement {
      * @throws IllegalArgumentException if maxValue is zero or negative
      */
     public ScaleDivider(DimensionalNumber maxValue) {
-        this(maxValue, new ScaleGroup());
+        this(maxValue, new ScaleGroup(), false);
     }
 
     /**
@@ -45,8 +46,9 @@ public class ScaleDivider extends ScaledElement {
      * @param maxValue   the maximum value to display on the scale (must be positive)
      * @param scaleGroup the scale group to use for managing scale
      */
-    public ScaleDivider(DimensionalNumber maxValue, ScaleGroup scaleGroup) {
+    public ScaleDivider(DimensionalNumber maxValue, ScaleGroup scaleGroup, boolean isInverted) {
         super(scaleGroup);
+        this.isInverted = isInverted;
         this.maxValue = maxValue.getValue();
         this.circleValues = calculateRoundTickValues(this.maxValue);
         this.formatter = new ValueFormatter(maxValue);
@@ -90,7 +92,9 @@ public class ScaleDivider extends ScaledElement {
 
     @Override
     public void draw(Subcanvas parent, Theme theme) {
-        Subcanvas g = new Subcanvas(parent, parent.getWidth() - offset, parent.getHeight(), offset, 0);
+        int x = isInverted ? 0:offset;
+
+        Subcanvas g = new Subcanvas(parent, parent.getWidth() - offset, parent.getHeight(), x, 0);
 
         // Draw small tick marks between circles
         // Every other tick should be bigger
@@ -111,7 +115,7 @@ public class ScaleDivider extends ScaledElement {
         // Draw circles with labels at round numbers
         for (double value : circleValues) {
             // Calculate x position based on value
-            int x = (int) (value * scaleGroup.getScale());
+            int x = getX(g, value);
 
             // Drop the first circle
             if (value > 0) {
@@ -147,10 +151,10 @@ public class ScaleDivider extends ScaledElement {
         double currentValue = 0;
         int tickIndex = 0;
         while (currentValue <= maxValue) {
-            int x = (int) (currentValue * scaleGroup.getScale());
+            int x = getX(g, currentValue);
 
             // Skip ticks that are within 2 pixels of any circle boundary
-            if (! isNearCircleBoundary(x)) {
+            if (! isNearCircleBoundary(x, g)) {
                 int tickHeight = TICK_HEIGHT;
                 int smallTickHeight = tickHeight / 2;
 
@@ -167,14 +171,22 @@ public class ScaleDivider extends ScaledElement {
         }
     }
 
-    private boolean isNearCircleBoundary(int tickX) {
+    private int getX(Subcanvas g, double currentValue) {
+        int x = (int) (currentValue * scaleGroup.getScale());
+        if (isInverted) {
+            x = g.getWidth() - x;
+        }
+        return x;
+    }
+
+    private boolean isNearCircleBoundary(int tickX, Subcanvas g) {
         // Check if tick is within 2 pixels of any circle boundary
         // Circle radius is CIRCLE_DIAMETER / 2, so boundary is at radius + 2 pixels from center
         int boundaryDistance = CIRCLE_DIAMETER / 2 + 2;
 
         for (double value : circleValues) {
             if (value > 0) { // Skip the first circle at 0
-                int circleX = (int) (value * scaleGroup.getScale());
+                int circleX = getX(g, value);
                 if (Math.abs(tickX - circleX) <= boundaryDistance) {
                     return true;
                 }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/ChartTest.java
@@ -141,7 +141,6 @@ public abstract class ChartTest extends ElasticElementTest {
     @Test
     public void testCanDrawSoloGroupInPreferredDimensions() {
         BenchmarkData data = mockBenchmarkData(1);
-        System.out.println("Data " + data);
         PlotDefinition plotDefinition = createPlotDefinition();
 
         Chart chart = createChart(plotDefinition, data);

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/TitleTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/TitleTest.java
@@ -1,15 +1,17 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TitleTest extends ElasticElementTest {
 
     @Test
     public void titleIncludesTitleText() {
         String titleText = "my cool chart";
-        var t = new Title(titleText);
+        var t = new Title(titleText, Optional.empty());
         String s = drawSvg(t);
         assertTrue(s.contains(titleText), s);
     }
@@ -18,7 +20,7 @@ class TitleTest extends ElasticElementTest {
     public void titleIncludesSubTitleText() {
         String titleText = "my cool chart";
         String subtitleText = "this is the explanation";
-        var t = new Title(titleText, subtitleText);
+        var t = new Title(titleText, subtitleText, Optional.empty());
         String s = drawSvg(t);
         assertTrue(s.contains(titleText), s);
         assertTrue(s.contains(subtitleText), s);


### PR DESCRIPTION
Resolves #453 

@insectengine, do you mind doing a visual review? This will go live on quarkus.io when merged. I haven't done your nice wings on the little scale lines, because I can do them in a separate PR. And I haven't done your text on the left-hand side because that's a bit more involved, so I'll do it in a follow-on PR as well. 

But I think even without those two, this is an improvement on the 'now'. Ignore the different numbers in the before and after, it was generated on different data!

**EDIT:** I just spotted I still haven't got the centering perfect, so I'll fix that. 

*Before:*

<img width="1338" height="1129" alt="image" src="https://github.com/user-attachments/assets/ee78eae7-10fb-4f2b-8742-004a7e9c54f5" />

*After:*

<img width="1262" height="1295" alt="image" src="https://github.com/user-attachments/assets/91840932-7687-4516-a751-f2f4ba8b0c0d" />

