### PR TITLE
Refactoring: Replace Optional<EmbedOptions> with EmbedOptions.DEFAULT

### DIFF
--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Bar.java
@@ -1,7 +1,5 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import java.util.Optional;
-
 import io.quarkus.infra.performance.graphics.Theme;
 import io.quarkus.infra.performance.graphics.charts.fonts.Alignment;
 import io.quarkus.infra.performance.graphics.charts.fonts.FontStyle;
@@ -31,10 +29,10 @@ public class Bar extends ScaledElement {
     private final boolean showFrameworkLabels;
     private boolean isInverted;
 
-    public Bar(Datapoint d, LabelGroup frameworkLabelGroup, LabelGroup valueLabelGroup, ScaleGroup scaleGroup, Optional<EmbedOptions> embedOptions) {
+    public Bar(Datapoint d, LabelGroup frameworkLabelGroup, LabelGroup valueLabelGroup, ScaleGroup scaleGroup, EmbedOptions embedOptions) {
         super(scaleGroup);
-        isInverted = embedOptions.isPresent() ? embedOptions.get().isInverted():false;
-        showFrameworkLabels = embedOptions.isPresent() ? embedOptions.get().showFrameworkLabels():true;
+        isInverted = embedOptions.isInverted();
+        showFrameworkLabels = embedOptions.showFrameworkLabels();
         this.d = d;
         double val = d.value().getValue();
 
@@ -44,7 +42,7 @@ public class Bar extends ScaledElement {
                 .setStyles(new FontStyle[]{BOLD, PLAIN})
                 .setTargetHeight(BAR_THICKNESS);
 
-        if (embedOptions.isPresent()) {
+        if (embedOptions.isEmbedded()) {
             frameworkLabel.setHorizontalAlignment(Alignment.CENTER);
         } else {
             frameworkLabel.setHorizontalAlignment(Alignment.RIGHT);

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/BarChart.java
@@ -26,14 +26,14 @@ public class BarChart extends SingleSeriesChart {
     private final ScaleGroup scaleGroup = new ScaleGroup();
 
     public BarChart(PlotDefinition plotDefinition, BenchmarkData bmData) {
-        this(plotDefinition, bmData, Optional.empty());
+        this(plotDefinition, bmData, EmbedOptions.DEFAULT);
     }
 
-    public BarChart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
+    public BarChart(PlotDefinition plotDefinition, BenchmarkData bmData, EmbedOptions embedOptions) {
         super(plotDefinition, bmData, embedOptions);
 
-        boolean isInverted = embedOptions.isPresent() ? embedOptions.get().isInverted():false;
-        boolean isEmbedded = embedOptions.isPresent();
+        boolean isInverted = embedOptions.isInverted();
+        boolean isEmbedded = embedOptions.isEmbedded();
 
         if (! isEmbedded) {
             this.fineprint = Optional.of(new FinePrint(bmData));
@@ -67,9 +67,6 @@ public class BarChart extends SingleSeriesChart {
 
     }
 
-    public BarChart(PlotDefinition pd, BenchmarkData bmData, EmbedOptions embedOptions) {
-        this(pd, bmData, Optional.of(embedOptions));
-    }
 
     private int countPartitions(List<Datapoint> data) {
         Category previousCategory = null;
@@ -116,7 +113,7 @@ public class BarChart extends SingleSeriesChart {
         }
 
         canvasWithMargins.setPaint(theme.text());
-        int titleOffset = embedOptions.isPresent() && ! embedOptions.get().isInverted() ? offset:0;
+        int titleOffset = embedOptions.isEmbedded() && ! embedOptions.isInverted() ? offset:0;
         Subcanvas titleCanvas = new Subcanvas(canvasWithMargins, canvasWithMargins.getWidth(), titleHeight,
                 titleOffset, 0);
         title.draw(titleCanvas, theme);
@@ -143,9 +140,9 @@ public class BarChart extends SingleSeriesChart {
 
         }
 
-        if (embedOptions.isPresent()) {
+        if (embedOptions.isEmbedded()) {
             barArea.setPaint(theme.divider());
-            int x = embedOptions.get().isInverted() ? barArea.getWidth() - offset:offset;
+            int x = embedOptions.isInverted() ? barArea.getWidth() - offset:offset;
             barArea.drawLine(x, 0, x, barArea.getHeight());
         }
 
@@ -168,7 +165,7 @@ public class BarChart extends SingleSeriesChart {
 
     @Override
     public int getCenteringOffset() {
-        if (embedOptions.isPresent() && embedOptions.get().showFrameworkLabels()) {
+        if (embedOptions.isEmbedded() && embedOptions.showFrameworkLabels()) {
             return - 1 * getLeftLabelWidth() / 2;
         } else {
             return super.getCenteringOffset();

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Chart.java
@@ -20,11 +20,11 @@ public abstract class Chart implements ElasticElement {
 
     final int xmargins = 20;
     final int ymargins = 20;
-    protected final Optional<EmbedOptions> embedOptions;
+    protected final EmbedOptions embedOptions;
     int lxmargin = xmargins;
     int rxmargin = xmargins;
 
-    protected Chart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
+    protected Chart(PlotDefinition plotDefinition, BenchmarkData bmData, EmbedOptions embedOptions) {
         this.metadata = bmData.config();
         this.embedOptions = embedOptions;
 
@@ -37,7 +37,7 @@ public abstract class Chart implements ElasticElement {
     }
 
     public Chart(PlotDefinition plotDefinition, BenchmarkData bmData) {
-        this(plotDefinition, bmData, Optional.empty());
+        this(plotDefinition, bmData, EmbedOptions.DEFAULT);
     }
 
     public void draw(Subcanvas g, Theme theme) {
@@ -54,7 +54,7 @@ public abstract class Chart implements ElasticElement {
         int canvasWidth = g.getWidth();
 
         // Don't fill background on embedded charts, because it's unnecessary, wastes xml space in the svg, and can overwrite other chart elements
-        if (embedOptions.isEmpty()) {
+        if (!embedOptions.isEmbedded()) {
             g.setPaint(theme.background());
             g.fill();
         }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/CubeChart.java
@@ -29,17 +29,13 @@ public class CubeChart extends SingleSeriesChart {
     private final LabelGroup valueLabelGroup = new LabelGroup();
 
     public CubeChart(PlotDefinition plotDefinition, BenchmarkData bmData) {
-        this(plotDefinition, bmData, Optional.empty());
+        this(plotDefinition, bmData, EmbedOptions.DEFAULT);
     }
 
     public CubeChart(PlotDefinition plotDefinition, BenchmarkData bmData, EmbedOptions embedOptions) {
-        this(plotDefinition, bmData, Optional.of(embedOptions));
-    }
-
-    public CubeChart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
         super(plotDefinition, bmData, embedOptions);
 
-        if (embedOptions.isEmpty()) {
+        if (!embedOptions.isEmbedded()) {
             this.fineprint = Optional.of(new FinePrint(bmData));
             children.add(fineprint.get());
         } else {

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/EmbedOptions.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/EmbedOptions.java
@@ -1,5 +1,10 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-public record EmbedOptions(boolean isInverted, boolean showFrameworkLabels) {
-   
+public record EmbedOptions(boolean isEmbedded, boolean isInverted, boolean showFrameworkLabels) {
+
+    public static final EmbedOptions DEFAULT = new EmbedOptions(false, false, true);
+
+    public EmbedOptions(boolean isInverted, boolean showFrameworkLabels) {
+        this(true, isInverted, showFrameworkLabels);
+    }
 }

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/SingleSeriesChart.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/SingleSeriesChart.java
@@ -2,7 +2,6 @@ package io.quarkus.infra.performance.graphics.charts;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 import io.quarkus.infra.performance.graphics.PlotDefinition;
 import io.quarkus.infra.performance.graphics.SingleSeriesPlotDefinition;
@@ -13,7 +12,7 @@ public abstract class SingleSeriesChart extends Chart {
     protected final List<Datapoint> data;
     protected final DimensionalNumber maxValue;
 
-    protected SingleSeriesChart(PlotDefinition plotDefinition, BenchmarkData bmData, Optional<EmbedOptions> embedOptions) {
+    protected SingleSeriesChart(PlotDefinition plotDefinition, BenchmarkData bmData, EmbedOptions embedOptions) {
         super(plotDefinition, bmData, embedOptions);
         if (plotDefinition instanceof SingleSeriesPlotDefinition singleSeriesPlotDefinition) {
             this.data = bmData.results().getDatasets(singleSeriesPlotDefinition.fun());

--- a/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Title.java
+++ b/graphics-generator/src/main/java/io/quarkus/infra/performance/graphics/charts/Title.java
@@ -1,7 +1,5 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import java.util.Optional;
-
 import io.quarkus.infra.performance.graphics.Theme;
 import io.quarkus.infra.performance.graphics.charts.fonts.Alignment;
 import io.quarkus.infra.performance.graphics.charts.fonts.Sizer;
@@ -22,17 +20,17 @@ public class Title implements ElasticElement {
     private final Label titleLabel;
     private final Label subtitleLabel;
 
-    public Title(String title, Optional<EmbedOptions> embedOptions) {
+    public Title(String title, EmbedOptions embedOptions) {
         this(title, "", embedOptions);
     }
 
-    public Title(String title, String subtitle, Optional<EmbedOptions> embedOptions) {
+    public Title(String title, String subtitle, EmbedOptions embedOptions) {
         this.title = title;
         titleLabel = new Label(title).setStyle(BOLD).setVerticalAlignment(VAlignment.TOP);
         this.subtitle = subtitle;
         subtitleLabel = new Label(subtitle).setStyle(ITALIC).setVerticalAlignment(VAlignment.TOP);
 
-        if (embedOptions.isPresent() && embedOptions.get().isInverted()) {
+        if (embedOptions.isInverted()) {
             titleLabel.setHorizontalAlignment(Alignment.RIGHT);
             subtitleLabel.setHorizontalAlignment(Alignment.RIGHT);
         }

--- a/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/TitleTest.java
+++ b/graphics-generator/src/test/java/io/quarkus/infra/performance/graphics/charts/TitleTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.infra.performance.graphics.charts;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,7 +9,7 @@ class TitleTest extends ElasticElementTest {
     @Test
     public void titleIncludesTitleText() {
         String titleText = "my cool chart";
-        var t = new Title(titleText, Optional.empty());
+        var t = new Title(titleText, EmbedOptions.DEFAULT);
         String s = drawSvg(t);
         assertTrue(s.contains(titleText), s);
     }
@@ -20,7 +18,7 @@ class TitleTest extends ElasticElementTest {
     public void titleIncludesSubTitleText() {
         String titleText = "my cool chart";
         String subtitleText = "this is the explanation";
-        var t = new Title(titleText, subtitleText, Optional.empty());
+        var t = new Title(titleText, subtitleText, EmbedOptions.DEFAULT);
         String s = drawSvg(t);
         assertTrue(s.contains(titleText), s);
         assertTrue(s.contains(subtitleText), s);


### PR DESCRIPTION
## Summary
- Replaces `Optional<EmbedOptions>` parameter anti-pattern with a non-null `EmbedOptions` throughout the chart hierarchy
- Adds `isEmbedded` property and `EmbedOptions.DEFAULT` constant, eliminating null checks and Optional wrapping
- Follow-up refactor from #467

## Test plan
- [x] All existing tests pass
- [x] Compilation clean with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)