### PR TITLE
Ignore files generated during test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+
+# Test-generated files
+/tuned/
+/latest.json
+/tempfile.json


### PR DESCRIPTION
When tests are running, they generate many files outside the ignored target directory. This is to test default behaviour, but it makes annoying clutter in git views if you look before they get tidied. Ignore those generated files.